### PR TITLE
Make sdtab.T work with interfaces again, and stretch to terminal width

### DIFF
--- a/internal/command/sandbox/get.go
+++ b/internal/command/sandbox/get.go
@@ -47,16 +47,9 @@ func get(cfg *config.SandboxGet, out io.Writer, name string) error {
 
 	switch cfg.OutputFormat {
 	case config.OutputFormatDefault:
-		t := sdtab.New[tableRow](out)
+		t := sdtab.New[*sbRow](out, &sbRow{})
 		t.AddHeader()
-		row := tableRow{
-			Name:        sb.Name,
-			Description: sb.Description,
-			Cluster:     sb.ClusterName,
-			Created:     sb.CreatedAt,
-			// TODO: Implement status.
-			Status: "Ready",
-		}
+		row := &sbRow{SandboxInfo: *sb, status: "Ready"}
 		t.AddRow(row)
 		if err := t.Flush(); err != nil {
 			return err

--- a/internal/command/sandbox/list.go
+++ b/internal/command/sandbox/list.go
@@ -44,17 +44,10 @@ func list(cfg *config.SandboxList, out io.Writer) error {
 
 	switch cfg.OutputFormat {
 	case config.OutputFormatDefault:
-		t := sdtab.New[tableRow](out)
+		t := sdtab.New[*sbRow](out, &sbRow{})
 		t.AddHeader()
 		for _, sbinfo := range sbs {
-			row := tableRow{
-				Name:        sbinfo.Name,
-				Description: sbinfo.Description,
-				Cluster:     sbinfo.ClusterName,
-				Created:     sbinfo.CreatedAt,
-				// TODO: Implement status.
-				Status: "Ready",
-			}
+			row := &sbRow{SandboxInfo: *sbinfo, status: "Ready"}
 			t.AddRow(row)
 		}
 		if err := t.Flush(); err != nil {

--- a/internal/command/sandbox/row.go
+++ b/internal/command/sandbox/row.go
@@ -1,0 +1,38 @@
+package sandbox
+
+import (
+	"github.com/signadot/cli/internal/sdtab"
+	"github.com/signadot/go-sdk/models"
+)
+
+type sbRow struct {
+	models.SandboxInfo
+	status string
+}
+
+func (r *sbRow) Columns() []sdtab.Column[*sbRow] {
+	return []sdtab.Column[*sbRow]{
+		{
+			Title: "NAME",
+			Get:   func(r *sbRow) string { return r.Name },
+		},
+		{
+			Title:    "DESCRIPTION",
+			Get:      func(r *sbRow) string { return r.Description },
+			Truncate: true,
+		},
+		{
+			Title: "CLUSTER",
+			Get:   func(r *sbRow) string { return r.ClusterName },
+		},
+		{
+			Title:    "CREATED",
+			Get:      func(r *sbRow) string { return r.CreatedAt },
+			Truncate: true,
+		},
+		{
+			Title: "STATUS",
+			Get:   func(r *sbRow) string { return r.status },
+		},
+	}
+}

--- a/internal/sdtab/struct.go
+++ b/internal/sdtab/struct.go
@@ -1,0 +1,63 @@
+package sdtab
+
+import (
+	"fmt"
+	"io"
+	"reflect"
+	"strings"
+)
+
+func taggedStructColumns[S any]() Columns[S] {
+	return taggedStruct[S]{}
+}
+
+// wrapper around tagged structs making them
+// implement Columns
+type taggedStruct[S any] struct{}
+
+func (t taggedStruct[S]) Columns() []Column[S] {
+	var row S
+	return structColumns[S](reflect.TypeOf(row))
+}
+
+func structColumns[R any](rowType reflect.Type) []Column[R] {
+	var res []Column[R]
+	for _, field := range reflect.VisibleFields(rowType) {
+		c := structFieldColumn[R](field)
+		if c != nil {
+			res = append(res, *c)
+		}
+	}
+	return res
+}
+
+func structFieldColumn[R any](f reflect.StructField) *Column[R] {
+	tag := f.Tag.Get("sdtab")
+	if tag == "" {
+		return nil
+	}
+
+	// Split by commas. The first part is the column title.
+	parts := strings.Split(tag, ",")
+	res := &Column[R]{
+		Title: parts[0],
+		Get: func(r R) string {
+			val := reflect.ValueOf(r).FieldByName(f.Name).Interface()
+			return fmt.Sprint(val)
+		},
+	}
+
+	// The rest of the comma-separated parts are "key" or "key=value" attributes.
+	for _, attr := range parts[1:] {
+		switch attr {
+		case "trunc":
+			res.Truncate = true
+		}
+	}
+
+	return res
+}
+
+func FromStruct[S any](w io.Writer) *T[S] {
+	return New[S](w, taggedStructColumns[S]())
+}

--- a/internal/sdtab/table.go
+++ b/internal/sdtab/table.go
@@ -12,9 +12,10 @@ import (
 )
 
 const (
-	margin      = "   "
-	truncSuffix = ".."
-	truncMinLen = 6
+	margin            = "   "
+	truncSuffix       = ".."
+	truncMinLen       = 6
+	stretchMinColumns = 5
 )
 
 type T[R any] struct {
@@ -23,6 +24,7 @@ type T[R any] struct {
 	columns    []Column[R]
 	termWidth  int
 	termHeight int
+	stretch    bool
 
 	rowBuf [][]string
 }
@@ -43,10 +45,18 @@ func New[R any](w io.Writer, cs Columns[R]) *T[R] {
 		out:     w,
 		columns: cs.Columns(),
 	}
+	if len(t.columns) >= stretchMinColumns {
+		t.stretch = true
+	}
 
 	// Try to auto-detect the terminal size.
 	t.detectTermSize()
 
+	return t
+}
+
+func (t *T[R]) SetStretch(v bool) *T[R] {
+	t.stretch = v
 	return t
 }
 

--- a/internal/sdtab/table_test.go
+++ b/internal/sdtab/table_test.go
@@ -29,7 +29,7 @@ func ExampleTruncate() {
 		},
 	}
 
-	tab := New[Data](os.Stdout)
+	tab := FromStruct[Data](os.Stdout)
 	tab.SetTermSize(100, 50)
 	tab.AddHeader()
 	for _, d := range testData {
@@ -40,9 +40,9 @@ func ExampleTruncate() {
 	// Output:
 	// A                             B
 	// a1                            b1
-	// aaaaaaaaaaaaaaaaaaaaaaaa...   b
-	// a                             bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb...
-	// aaaaaaaaaaaaaaaaaaaaaaaa...   bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb...
+	// aaaaaaaaaaaaaaaaaaaaaaaaa..   b
+	// a                             bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb..
+	// aaaaaaaaaaaaaaaaaaaaaaaaa..   bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb..
 }
 
 func FuzzTruncate(f *testing.F) {


### PR DESCRIPTION
Using interface, we can avoid copying the struct at the call-site,
and more easily make adaptors for different types just by wrapping them.
At the definition site, it is slightly more verbose but at the call site
of AddRow, it is less verbose.

This PR however keeps the pure struct tag based approach.

Also, modified the calculation of table widths to stretch to terminal
width.