### PR TITLE
make the config initialization only apply to api subcommands

### DIFF
--- a/internal/command/cluster/command.go
+++ b/internal/command/cluster/command.go
@@ -6,8 +6,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func New(root *config.Root) *cobra.Command {
-	cfg := &config.Cluster{Root: root}
+func New(api *config.Api) *cobra.Command {
+	cfg := &config.Cluster{Api: api}
 	cmd := &cobra.Command{
 		Use:   "cluster",
 		Short: "Manage connections between your Kubernetes clusters and Signadot",

--- a/internal/command/cluster/connect.go
+++ b/internal/command/cluster/connect.go
@@ -23,6 +23,9 @@ func newConnect(cluster *config.Cluster) *cobra.Command {
 }
 
 func connect(cfg *config.ClusterConnect) error {
+	if err := cfg.InitAPIConfig(); err != nil {
+		return err
+	}
 	// TODO: Implement cluster connect.
 
 	return nil

--- a/internal/command/cluster/token/create.go
+++ b/internal/command/cluster/token/create.go
@@ -23,6 +23,9 @@ func newCreate(token *config.ClusterToken) *cobra.Command {
 }
 
 func create(cfg *config.ClusterTokenCreate) error {
+	if err := cfg.InitAPIConfig(); err != nil {
+		return err
+	}
 	// TODO: Implement cluster token create.
 
 	return nil

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -8,7 +8,7 @@ import (
 )
 
 func New() *cobra.Command {
-	cfg := &config.Root{}
+	cfg := &config.Api{}
 	cobra.OnInitialize(cfg.Init)
 
 	cmd := &cobra.Command{

--- a/internal/command/sandbox/command.go
+++ b/internal/command/sandbox/command.go
@@ -5,8 +5,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func New(root *config.Root) *cobra.Command {
-	cfg := &config.Sandbox{Root: root}
+func New(api *config.Api) *cobra.Command {
+	cfg := &config.Sandbox{Api: api}
 
 	cmd := &cobra.Command{
 		Use:   "sandbox",

--- a/internal/command/sandbox/create.go
+++ b/internal/command/sandbox/create.go
@@ -30,6 +30,9 @@ func newCreate(sandbox *config.Sandbox) *cobra.Command {
 }
 
 func create(cfg *config.SandboxCreate, out io.Writer) error {
+	if err := cfg.InitAPIConfig(); err != nil {
+		return err
+	}
 	if cfg.Filename == "" {
 		return errors.New("must specify sandbox request file with '-f' flag")
 	}

--- a/internal/command/sandbox/delete.go
+++ b/internal/command/sandbox/delete.go
@@ -30,6 +30,9 @@ func newDelete(sandbox *config.Sandbox) *cobra.Command {
 }
 
 func delete(cfg *config.SandboxDelete, out io.Writer, args []string) error {
+	if err := cfg.InitAPIConfig(); err != nil {
+		return err
+	}
 	if cfg.Filename == "" && len(args) == 0 {
 		return errors.New("must specify either filename or sandbox name")
 	}

--- a/internal/command/sandbox/get.go
+++ b/internal/command/sandbox/get.go
@@ -29,6 +29,9 @@ func newGet(sandbox *config.Sandbox) *cobra.Command {
 }
 
 func get(cfg *config.SandboxGet, out io.Writer, name string) error {
+	if err := cfg.InitAPIConfig(); err != nil {
+		return err
+	}
 	// TODO: Use GetSandboxByName when it's available.
 	resp, err := cfg.Client.Sandboxes.GetSandboxes(sandboxes.NewGetSandboxesParams().WithOrgName(cfg.Org), cfg.AuthInfo)
 	if err != nil {

--- a/internal/command/sandbox/list.go
+++ b/internal/command/sandbox/list.go
@@ -36,6 +36,9 @@ type tableRow struct {
 }
 
 func list(cfg *config.SandboxList, out io.Writer) error {
+	if err := cfg.InitAPIConfig(); err != nil {
+		return err
+	}
 	resp, err := cfg.Client.Sandboxes.GetSandboxes(sandboxes.NewGetSandboxesParams().WithOrgName(cfg.Org), cfg.AuthInfo)
 	if err != nil {
 		return err

--- a/internal/config/api.go
+++ b/internal/config/api.go
@@ -1,0 +1,53 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+
+	"github.com/go-openapi/runtime"
+	"github.com/signadot/cli/internal/auth"
+	"github.com/signadot/go-sdk/client"
+	"github.com/spf13/viper"
+)
+
+type Api struct {
+	Root
+
+	// Config file values
+	Org string
+
+	// Runtime values
+	Client   *client.SignadotAPI
+	AuthInfo runtime.ClientAuthInfoWriter
+}
+
+func (a *Api) InitAPIConfig() error {
+
+	a.Org = viper.GetString("org")
+	if a.Org == "" {
+		return errors.New("Signadot Org name must be specified through either the SIGNADOT_ORG env var or the 'org' field in ~/.signadot/config.yaml")
+	}
+
+	apiKey := viper.GetString("api_key")
+	if apiKey == "" {
+		return errors.New("Signadot API key must be specified through either the SIGNADOT_API_KEY env var or the 'api_key' field in ~/.signadot/config.yaml")
+	}
+
+	a.Client = client.Default
+	a.AuthInfo = auth.Authenticator(apiKey)
+
+	// Allow API URL to be overridden (e.g. for talking to dev/staging).
+	if apiURL := viper.GetString("api_url"); apiURL != "" {
+		u, err := url.Parse(apiURL)
+		if err != nil {
+			return fmt.Errorf("invalid api_url: %w", err)
+		}
+		a.Client = client.NewHTTPClientWithConfig(nil, &client.TransportConfig{
+			Host:     u.Host,
+			BasePath: client.DefaultBasePath,
+			Schemes:  []string{u.Scheme},
+		})
+	}
+	return nil
+}

--- a/internal/config/cluster.go
+++ b/internal/config/cluster.go
@@ -3,7 +3,7 @@ package config
 import "github.com/spf13/cobra"
 
 type Cluster struct {
-	*Root
+	*Api
 }
 
 type ClusterConnect struct {
@@ -17,4 +17,3 @@ func (c *ClusterConnect) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&c.ClusterName, "name", "", "assign a name for this cluster as it will appear within Signadot")
 	cmd.MarkFlagRequired("name")
 }
-

--- a/internal/config/root.go
+++ b/internal/config/root.go
@@ -1,15 +1,9 @@
 package config
 
 import (
-	"errors"
-	"fmt"
-	"net/url"
 	"os"
 	"path/filepath"
 
-	"github.com/go-openapi/runtime"
-	"github.com/signadot/cli/internal/auth"
-	"github.com/signadot/go-sdk/client"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -18,13 +12,6 @@ type Root struct {
 	// Flags
 	ConfigFile   string
 	OutputFormat OutputFormat
-
-	// Config file values
-	Org string
-
-	// Runtime values
-	Client   *client.SignadotAPI
-	AuthInfo runtime.ClientAuthInfoWriter
 }
 
 func (c *Root) AddFlags(cmd *cobra.Command) {
@@ -54,37 +41,11 @@ func (c *Root) init() error {
 	viper.AutomaticEnv()
 
 	if err := viper.ReadInConfig(); err != nil {
-		// The config file is optional since required params (org, apikey) can
-		// be set by env var instead.
+		// The config file is optional (required params (org, apikey) can
+		// be set by env var instead).
 		if _, ok := err.(viper.ConfigFileNotFoundError); !ok {
 			return err
 		}
-	}
-
-	c.Org = viper.GetString("org")
-	if c.Org == "" {
-		return errors.New("Signadot Org name must be specified through either the SIGNADOT_ORG env var or the 'org' field in ~/.signadot/config.yaml")
-	}
-
-	apiKey := viper.GetString("api_key")
-	if apiKey == "" {
-		return errors.New("Signadot API key must be specified through either the SIGNADOT_API_KEY env var or the 'api_key' field in ~/.signadot/config.yaml")
-	}
-
-	c.Client = client.Default
-	c.AuthInfo = auth.Authenticator(apiKey)
-
-	// Allow API URL to be overridden (e.g. for talking to dev/staging).
-	if apiURL := viper.GetString("api_url"); apiURL != "" {
-		u, err := url.Parse(apiURL)
-		if err != nil {
-			return fmt.Errorf("invalid api_url: %w", err)
-		}
-		c.Client = client.NewHTTPClientWithConfig(nil, &client.TransportConfig{
-			Host:     u.Host,
-			BasePath: client.DefaultBasePath,
-			Schemes:  []string{u.Scheme},
-		})
 	}
 
 	return nil

--- a/internal/config/sandbox.go
+++ b/internal/config/sandbox.go
@@ -3,7 +3,7 @@ package config
 import "github.com/spf13/cobra"
 
 type Sandbox struct {
-	*Root
+	*Api
 }
 
 type SandboxCreate struct {


### PR DESCRIPTION
Without this change, running 'signadot help' or 'signadot autocomplete'
without SIGNADOT_ORG configured would throw an unhelpful error message:
```
22-05-09 scott@pavillion cli % go run ./cmd/signadot help
Error: Signadot Org name must be specified through either the SIGNADOT_ORG env var or the 'org' field in ~/.signadot/config.yaml
exit status 1
```

with this change we have:
```
22-05-09 scott@pavillion cli % go run ./cmd/signadot help
Command-line interface for Signadot

Usage:
  signadot [command]

Available Commands:
  cluster     Manage connections between your Kubernetes clusters and Signadot
  completion  Generate the autocompletion script for the specified shell
  help        Help about any command
  sandbox     Inspect and manipulate sandboxes

Flags:
      --config string   config file (default is $HOME/.signadot/config.yaml)
  -h, --help            help for signadot
  -o, --output string   output format (json|yaml)

Use "signadot [command] --help" for more information about a command.
```
and, in case SIGNADOT_ORG is not set we have something like this for api specific sub-commands:
```
22-05-09 scott@pavillion cli % go run ./cmd/signadot sandbox list
Error: Signadot Org name must be specified through either the SIGNADOT_ORG env var or the 'org' field in ~/.signadot/config.yaml
Usage:
  signadot sandbox list [flags]

Flags:
  -h, --help   help for list

Global Flags:
      --config string   config file (default is $HOME/.signadot/config.yaml)
  -o, --output string   output format (json|yaml)

exit status 1
22-05-09 scott@pavillion cli %
```
