### PR TITLE
fix docker amd/alpine problem

### DIFF
--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -9,6 +9,8 @@ builds:
   goarch:
   - amd64
   - arm64
+  env:
+  - CGO_ENABLED=0
   ldflags:
   - -X github.com/signadot/cli/internal/buildinfo.Version=v{{ .Version }}
   - -X github.com/signadot/cli/internal/buildinfo.GitCommit={{ .ShortCommit }}


### PR DESCRIPTION
see
https://stackoverflow.com/questions/66963068/docker-alpine-executable-binary-not-found-even-if-in-path

Without this, running on docker with platform amd64 gave a very mysterious "not found" error for the executable.
