### PR TITLE
reduce-wait-timeout

### DIFF
--- a/internal/config/sandbox.go
+++ b/internal/config/sandbox.go
@@ -23,7 +23,7 @@ type SandboxApply struct {
 func (c *SandboxApply) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&c.Filename, "filename", "f", "", "YAML or JSON file containing the sandbox creation request")
 	cmd.Flags().BoolVar(&c.Wait, "wait", true, "wait for the sandbox status to be Ready before returning")
-	cmd.Flags().DurationVar(&c.WaitTimeout, "wait-timeout", 5*time.Minute, "timeout when waiting for the sandbox to be Ready")
+	cmd.Flags().DurationVar(&c.WaitTimeout, "wait-timeout", 3*time.Minute, "timeout when waiting for the sandbox to be Ready")
 	cmd.MarkFlagRequired("filename")
 	cmd.Flags().Var(&c.TemplateVals, "set", "--set var=val")
 }


### PR DESCRIPTION
Following a discussion about the time it takes to discover a k8s-config error that occurs late and how this is inconvenient for interactive use, this PR proposing reducing the default wait timeout to 3m from 5m.

Rational: most clusters most of the time will probably succeed with 3m, but there will be some failures now and then due to performance bottlenecks.  With 5m, almost all  failures to become ready within the allotted time will be not be due performance bottlenecks.  5m might be a good in-CI default, but 1m would probably be best for interactive use.  Since users are discovering by interactive use, this seems to be a good compromise.  They can up the limit if it starts causing problems in CI due to cluster performance bottlenecks.

