### PR TITLE
update go.sum to correct dependency v0.3.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/docker/go-units v0.4.0
 	github.com/go-openapi/runtime v0.24.2
 	github.com/go-openapi/strfmt v0.21.3
-	github.com/signadot/go-sdk v0.3.4
 	github.com/spf13/cobra v1.4.0
 	github.com/spf13/viper v1.11.0
 	github.com/theckman/yacspin v0.13.12
@@ -40,6 +39,7 @@ require (
 	github.com/pelletier/go-toml v1.9.4 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.0-beta.8 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
+	github.com/signadot/go-sdk v0.3.4 // indirect
 	github.com/spf13/afero v1.8.2 // indirect
 	github.com/spf13/cast v1.4.1 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -263,8 +263,8 @@ github.com/rogpeppe/go-internal v1.1.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/rogpeppe/go-internal v1.2.2/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/signadot/go-sdk v0.3.4 h1:RZcReiR4bxOOUij3BcDeGqAnlA0rJxBuwpqjxpq7Wd0=
-github.com/signadot/go-sdk v0.3.4/go.mod h1:Oil8cvz7uZLsKPqW8sR+0I0ee6nGzJ3eh3UYTO9fcpo=
+github.com/signadot/go-sdk v0.3.4 h1:YnDs6En9p5VS0E+hzCuzAVsVpGHPmN7vSAmr4vALTFA=
+github.com/signadot/go-sdk v0.3.4/go.mod h1:H7iGs3dCIEJo6Shl9Jhkc/U0ZXwUKGzFBpfRz3vO2eo=
 github.com/sirupsen/logrus v1.4.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=


### PR DESCRIPTION
A prior version of v0.3.4 was unintentionally pushed. It has now been removed and we're updating instead to the correct version of the go-sdk dependency. 