### PR TITLE
Fix problem reading config in local connect, and some other improvements

### DIFF
--- a/internal/config/locald.go
+++ b/internal/config/locald.go
@@ -51,6 +51,8 @@ func (ld *LocalDaemon) InitLocalDaemon() error {
 	if err := json.Unmarshal(ciBytes, ciConfig); err != nil {
 		return err
 	}
+
+	viper.Set("api_url", ciConfig.API.APIURL)
 	viper.Set("api_key", ciConfig.APIKey)
 	if err := ciConfig.API.InitAPITransport(ciConfig.APIKey); err != nil {
 		return err

--- a/internal/locald/sandboxmanager/grpc_server.go
+++ b/internal/locald/sandboxmanager/grpc_server.go
@@ -62,7 +62,7 @@ func newSandboxManagerGRPCServer(apiConfig *cliconfig.API, portForward *portforw
 
 func (s *grpcServer) ApplySandbox(ctx context.Context, req *sbapi.ApplySandboxRequest) (*sbapi.ApplySandboxResponse, error) {
 	if !s.isSBManagerReadyFunc() {
-		return nil, status.Errorf(codes.Unavailable, "sandboxmanager is still starting")
+		return nil, status.Errorf(codes.FailedPrecondition, "sandboxmanager is still starting")
 	}
 	sbSpec, err := sbapi.ToModelsSandboxSpec(req.SandboxSpec)
 	if err != nil {

--- a/internal/locald/sandboxmanager/sandbox_monitor.go
+++ b/internal/locald/sandboxmanager/sandbox_monitor.go
@@ -146,6 +146,7 @@ func (sbm *sbMonitor) readStream(sbwClient clapi.TunnelAPI_WatchSandboxClient) e
 		case codes.Internal:
 			sbm.log.Error("sandbox watch: internal grpc error",
 				"error", err)
+			<-time.After(3 * time.Second)
 		case codes.NotFound:
 			sbm.log.Info("sandbox watch: sandbox not found")
 			err = nil


### PR DESCRIPTION
Fix for, the following bug, reported by @jmsktm :

```
When I initially ran the below sandbox apply command:
signadot sandbox apply -f xxxx --config ~/.signadot/staging.yaml

- When there was a local component: It returned a 401 error
- When I removed the local component: the sandbox was applied successfully
```