### PR TITLE
support for macos vpn route commands

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/nsf/jsondiff v0.0.0-20210926074059-1e845ec5d249
 	github.com/signadot/go-sdk v0.3.8-0.20230629093216-a080b761faca
-	github.com/signadot/libconnect v0.1.1-0.20230710094039-19477b1d25e8
+	github.com/signadot/libconnect v0.1.1-0.20230710153934-ac5281e7edcc
 	github.com/spf13/cobra v1.6.0
 	github.com/spf13/viper v1.11.0
 	github.com/theckman/yacspin v0.13.12

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/nsf/jsondiff v0.0.0-20210926074059-1e845ec5d249
 	github.com/signadot/go-sdk v0.3.8-0.20230629093216-a080b761faca
-	github.com/signadot/libconnect v0.1.1-0.20230707142131-ffcf148fc365
+	github.com/signadot/libconnect v0.1.1-0.20230710094039-19477b1d25e8
 	github.com/spf13/cobra v1.6.0
 	github.com/spf13/viper v1.11.0
 	github.com/theckman/yacspin v0.13.12
@@ -99,4 +99,4 @@ require (
 )
 
 // Used for local dev
-// replace github.com/signadot/libconnect => ../libconnect/
+//replace github.com/signadot/libconnect => ../libconnect/

--- a/go.sum
+++ b/go.sum
@@ -331,8 +331,8 @@ github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZV
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/signadot/go-sdk v0.3.8-0.20230629093216-a080b761faca h1:0LFuVy9H3JC26qUPfJSRHfDMTasgMoQqaIH7RW/D7TM=
 github.com/signadot/go-sdk v0.3.8-0.20230629093216-a080b761faca/go.mod h1:p6ntIt1py1DoLJdtR4DQCVAg+FzHyTgmK6CTaUtnV3w=
-github.com/signadot/libconnect v0.1.1-0.20230707142131-ffcf148fc365 h1:deEcY8TysyWG+q7ySupcrQUXrynJNN7glrUD7SrvpAE=
-github.com/signadot/libconnect v0.1.1-0.20230707142131-ffcf148fc365/go.mod h1:E6ExZIKzVtccOHRZxc11OiDnB0/s6ecSjs8Y+STjWL8=
+github.com/signadot/libconnect v0.1.1-0.20230710094039-19477b1d25e8 h1:AEiVvJe7nTefUCCy/MLnf6vO2WXXaLbbSfv88bK/J/g=
+github.com/signadot/libconnect v0.1.1-0.20230710094039-19477b1d25e8/go.mod h1:E6ExZIKzVtccOHRZxc11OiDnB0/s6ecSjs8Y+STjWL8=
 github.com/sirupsen/logrus v1.4.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=

--- a/go.sum
+++ b/go.sum
@@ -333,6 +333,8 @@ github.com/signadot/go-sdk v0.3.8-0.20230629093216-a080b761faca h1:0LFuVy9H3JC26
 github.com/signadot/go-sdk v0.3.8-0.20230629093216-a080b761faca/go.mod h1:p6ntIt1py1DoLJdtR4DQCVAg+FzHyTgmK6CTaUtnV3w=
 github.com/signadot/libconnect v0.1.1-0.20230710094039-19477b1d25e8 h1:AEiVvJe7nTefUCCy/MLnf6vO2WXXaLbbSfv88bK/J/g=
 github.com/signadot/libconnect v0.1.1-0.20230710094039-19477b1d25e8/go.mod h1:E6ExZIKzVtccOHRZxc11OiDnB0/s6ecSjs8Y+STjWL8=
+github.com/signadot/libconnect v0.1.1-0.20230710153934-ac5281e7edcc h1:8a/HhvaEJnf2RtxVttpmNxWf8mZeL19rP0XzMMrLYoY=
+github.com/signadot/libconnect v0.1.1-0.20230710153934-ac5281e7edcc/go.mod h1:E6ExZIKzVtccOHRZxc11OiDnB0/s6ecSjs8Y+STjWL8=
 github.com/sirupsen/logrus v1.4.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=

--- a/internal/command/local/connect.go
+++ b/internal/command/local/connect.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
 
 	"github.com/signadot/cli/internal/config"
 	"github.com/signadot/cli/internal/utils/system"
@@ -13,6 +14,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"golang.org/x/exp/slog"
+	"sigs.k8s.io/yaml"
 )
 
 func newConnect(localConfig *config.Local) *cobra.Command {
@@ -74,7 +76,6 @@ func runConnect(cmd *cobra.Command, log io.Writer, cfg *config.LocalConnect, arg
 		SignadotDir:      signadotDir,
 		APIPort:          6666,
 		LocalNetPort:     6667,
-		Cluster:          cfg.Cluster,
 		UID:              os.Geteuid(),
 		GID:              os.Getegid(),
 		UIDHome:          homeDir,
@@ -83,6 +84,13 @@ func runConnect(cmd *cobra.Command, log io.Writer, cfg *config.LocalConnect, arg
 		API:              cfg.API,
 		APIKey:           viper.GetString("api_key"),
 		Debug:            cfg.LocalConfig.Debug,
+	}
+	if cfg.DumpCIConfig {
+		d, _ := yaml.Marshal(ciConfig)
+		err := os.WriteFile(filepath.Join(signadotDir, "ci-config.yaml"), d, 0644)
+		if err != nil {
+			return err
+		}
 	}
 	logger, err := getLogger(ciConfig)
 	if err != nil {

--- a/internal/config/local.go
+++ b/internal/config/local.go
@@ -79,6 +79,7 @@ type LocalConnect struct {
 
 	// Hidden Flags
 	Unprivileged bool
+	DumpCIConfig bool
 }
 
 func (c *LocalConnect) AddFlags(cmd *cobra.Command) {
@@ -87,6 +88,8 @@ func (c *LocalConnect) AddFlags(cmd *cobra.Command) {
 
 	cmd.Flags().BoolVar(&c.Unprivileged, "unprivileged", false, "run without root priveleges")
 	cmd.Flags().MarkHidden("unprivileged")
+	cmd.Flags().BoolVar(&c.DumpCIConfig, "dump-ci-config", false, "dump connect invocation config")
+	cmd.Flags().MarkHidden("dump-ci-config")
 }
 
 type LocalDisconnect struct {

--- a/internal/config/locald.go
+++ b/internal/config/locald.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -9,6 +8,7 @@ import (
 	connectcfg "github.com/signadot/libconnect/config"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"sigs.k8s.io/yaml"
 )
 
 const (
@@ -48,7 +48,7 @@ func (ld *LocalDaemon) InitLocalDaemon() error {
 		}
 	}
 	ciConfig := &ConnectInvocationConfig{}
-	if err := json.Unmarshal(ciBytes, ciConfig); err != nil {
+	if err := yaml.Unmarshal(ciBytes, ciConfig); err != nil {
 		return err
 	}
 
@@ -70,7 +70,6 @@ func (ld *LocalDaemon) InitLocalDaemon() error {
 // be passed without plumbing the command line
 type ConnectInvocationConfig struct {
 	Unprivileged     bool                         `json:"unprivileged"`
-	Cluster          string                       `json:"cluster"`
 	APIPort          uint16                       `json:"apiPort"`
 	LocalNetPort     uint16                       `json:"localNetPort"`
 	SignadotDir      string                       `json:"signadotDir"`
@@ -101,6 +100,6 @@ func (ciConfig *ConnectInvocationConfig) GetLogName() string {
 func (c *LocalDaemon) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&c.DaemonRun, "daemon", false, "run in background as daemon")
 
-	cmd.Flags().StringVar(&c.ConnectInvocationConfigFile, "connect-invocation-config-file", "", "by-pass calling signadot local connect (hidden)")
+	cmd.Flags().StringVar(&c.ConnectInvocationConfigFile, "ci-config-file", "", "by-pass calling signadot local connect (hidden)")
 	cmd.Flags().MarkHidden("connect-invocation-config-file")
 }


### PR DESCRIPTION
see https://github.com/signadot/libconnect/pull/25

Also includes some fixes/improvements:

- cluster is no longer part of ci-config (it is in the connection config)
- mechanism to pass/dump ci-config is improved