### PR TITLE
minimal change to support new tolocal fields from cluster

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/nsf/jsondiff v0.0.0-20210926074059-1e845ec5d249
 	github.com/signadot/go-sdk v0.3.8-0.20230629093216-a080b761faca
-	github.com/signadot/libconnect v0.1.1-0.20230707142131-ffcf148fc365
+	github.com/signadot/libconnect v0.1.1-0.20230710220506-6d9e83e7f5ea
 	github.com/spf13/cobra v1.6.0
 	github.com/spf13/viper v1.11.0
 	github.com/theckman/yacspin v0.13.12

--- a/go.sum
+++ b/go.sum
@@ -331,8 +331,8 @@ github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZV
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/signadot/go-sdk v0.3.8-0.20230629093216-a080b761faca h1:0LFuVy9H3JC26qUPfJSRHfDMTasgMoQqaIH7RW/D7TM=
 github.com/signadot/go-sdk v0.3.8-0.20230629093216-a080b761faca/go.mod h1:p6ntIt1py1DoLJdtR4DQCVAg+FzHyTgmK6CTaUtnV3w=
-github.com/signadot/libconnect v0.1.1-0.20230707142131-ffcf148fc365 h1:deEcY8TysyWG+q7ySupcrQUXrynJNN7glrUD7SrvpAE=
-github.com/signadot/libconnect v0.1.1-0.20230707142131-ffcf148fc365/go.mod h1:E6ExZIKzVtccOHRZxc11OiDnB0/s6ecSjs8Y+STjWL8=
+github.com/signadot/libconnect v0.1.1-0.20230710220506-6d9e83e7f5ea h1:6ZtvJjOwAUI7TRMuYR38KLUPLeSO8/pRLdKgUA/hdK4=
+github.com/signadot/libconnect v0.1.1-0.20230710220506-6d9e83e7f5ea/go.mod h1:E6ExZIKzVtccOHRZxc11OiDnB0/s6ecSjs8Y+STjWL8=
 github.com/sirupsen/logrus v1.4.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=

--- a/internal/locald/sandboxmanager/sandbox_monitor.go
+++ b/internal/locald/sandboxmanager/sandbox_monitor.go
@@ -28,7 +28,7 @@ type sbMonitor struct {
 	log         *slog.Logger
 	doneCh      chan struct{}
 	reconcileCh chan struct{}
-	status      *clapi.WatchSandboxStatus
+	status      *clapi.WatchSandboxResponse
 	revtuns     map[string]*rt
 	locals      map[string]*models.Local
 }
@@ -49,7 +49,7 @@ func newSBMonitor(rk string, clapiClient clapiclient.Client, rtClient revtun.Cli
 	return res
 }
 
-func (sbm *sbMonitor) getStatus() *clapi.WatchSandboxStatus {
+func (sbm *sbMonitor) getStatus() *clapi.WatchSandboxResponse {
 	sbm.Lock()
 	defer sbm.Unlock()
 	return sbm.status
@@ -91,7 +91,7 @@ reconcileLoop:
 
 	// we're done, clean up revtuns and parent delete func
 	sbm.log.Debug("cleaning up status and locals and parent")
-	sbm.updateSandboxStatus(&clapi.WatchSandboxStatus{})
+	sbm.updateSandboxStatus(&clapi.WatchSandboxResponse{})
 	sbm.updateLocalsSpec(nil)
 	sbm.reconcile()
 	sbm.delFn()
@@ -124,7 +124,7 @@ func (sbm *sbMonitor) readStream(sbwClient clapi.TunnelAPI_WatchSandboxClient) e
 	var (
 		ok         bool
 		err        error
-		sbStatus   *clapi.WatchSandboxStatus
+		sbStatus   *clapi.WatchSandboxResponse
 		grpcStatus *status.Status
 	)
 	for {
@@ -158,7 +158,7 @@ func (sbm *sbMonitor) readStream(sbwClient clapi.TunnelAPI_WatchSandboxClient) e
 	return err
 }
 
-func (sbm *sbMonitor) updateSandboxStatus(st *clapi.WatchSandboxStatus) {
+func (sbm *sbMonitor) updateSandboxStatus(st *clapi.WatchSandboxResponse) {
 	sbm.Lock()
 	defer sbm.Unlock()
 
@@ -214,7 +214,7 @@ func (sbm *sbMonitor) reconcile() {
 
 	// reconcile
 	sbm.log.Debug("reconciling tunnels")
-	statusXWs := make(map[string]*clapi.WatchSandboxStatus_ExternalWorkload, len(sbm.status.ExternalWorkloads))
+	statusXWs := make(map[string]*clapi.WatchSandboxResponse_ExternalWorkload, len(sbm.status.ExternalWorkloads))
 	// put the xwls in a map
 	for _, xw := range sbm.status.ExternalWorkloads {
 		statusXWs[xw.Name] = xw


### PR DESCRIPTION
this deliberately makes no attempt to consume the new info, as part of prioritising operator changes for release.

depends on https://github.com/signadot/signadot/pull/3438

and https://github.com/signadot/libconnect/pull/26