### PR TITLE
Improvements to sandbox manager in locald

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/nsf/jsondiff v0.0.0-20210926074059-1e845ec5d249
 	github.com/signadot/go-sdk v0.3.8-0.20230629093216-a080b761faca
-	github.com/signadot/libconnect v0.1.1-0.20230713155953-1b28070818a7
+	github.com/signadot/libconnect v0.1.1-0.20230714131709-81ce63dd44b5
 	github.com/spf13/cobra v1.6.0
 	github.com/spf13/viper v1.11.0
 	github.com/theckman/yacspin v0.13.12

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/nsf/jsondiff v0.0.0-20210926074059-1e845ec5d249
 	github.com/signadot/go-sdk v0.3.8-0.20230629093216-a080b761faca
-	github.com/signadot/libconnect v0.1.1-0.20230714131709-81ce63dd44b5
+	github.com/signadot/libconnect v0.1.1-0.20230714174348-d1651c8dcad6
 	github.com/spf13/cobra v1.6.0
 	github.com/spf13/viper v1.11.0
 	github.com/theckman/yacspin v0.13.12

--- a/go.sum
+++ b/go.sum
@@ -331,8 +331,8 @@ github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZV
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/signadot/go-sdk v0.3.8-0.20230629093216-a080b761faca h1:0LFuVy9H3JC26qUPfJSRHfDMTasgMoQqaIH7RW/D7TM=
 github.com/signadot/go-sdk v0.3.8-0.20230629093216-a080b761faca/go.mod h1:p6ntIt1py1DoLJdtR4DQCVAg+FzHyTgmK6CTaUtnV3w=
-github.com/signadot/libconnect v0.1.1-0.20230714131709-81ce63dd44b5 h1:QiT5mwAMfiRsceDnFd3J/sZc/86zHK2FKJVK5p6KFjk=
-github.com/signadot/libconnect v0.1.1-0.20230714131709-81ce63dd44b5/go.mod h1:E6ExZIKzVtccOHRZxc11OiDnB0/s6ecSjs8Y+STjWL8=
+github.com/signadot/libconnect v0.1.1-0.20230714174348-d1651c8dcad6 h1:N0x9DtdomBFEo6oUiN7T7w8RrrRX8GmRFbXWOZEXrR4=
+github.com/signadot/libconnect v0.1.1-0.20230714174348-d1651c8dcad6/go.mod h1:E6ExZIKzVtccOHRZxc11OiDnB0/s6ecSjs8Y+STjWL8=
 github.com/sirupsen/logrus v1.4.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=

--- a/go.sum
+++ b/go.sum
@@ -331,8 +331,8 @@ github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZV
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/signadot/go-sdk v0.3.8-0.20230629093216-a080b761faca h1:0LFuVy9H3JC26qUPfJSRHfDMTasgMoQqaIH7RW/D7TM=
 github.com/signadot/go-sdk v0.3.8-0.20230629093216-a080b761faca/go.mod h1:p6ntIt1py1DoLJdtR4DQCVAg+FzHyTgmK6CTaUtnV3w=
-github.com/signadot/libconnect v0.1.1-0.20230713155953-1b28070818a7 h1:3VMoOwTgivx89ehT6Vu2TVBqUaRko68P1rDhtE5LczA=
-github.com/signadot/libconnect v0.1.1-0.20230713155953-1b28070818a7/go.mod h1:E6ExZIKzVtccOHRZxc11OiDnB0/s6ecSjs8Y+STjWL8=
+github.com/signadot/libconnect v0.1.1-0.20230714131709-81ce63dd44b5 h1:QiT5mwAMfiRsceDnFd3J/sZc/86zHK2FKJVK5p6KFjk=
+github.com/signadot/libconnect v0.1.1-0.20230714131709-81ce63dd44b5/go.mod h1:E6ExZIKzVtccOHRZxc11OiDnB0/s6ecSjs8Y+STjWL8=
 github.com/sirupsen/logrus v1.4.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=

--- a/internal/locald/sandboxmanager/sandbox_manager.go
+++ b/internal/locald/sandboxmanager/sandbox_manager.go
@@ -31,6 +31,7 @@ type sandboxManager struct {
 	apiPort      uint16
 	hostname     string
 	grpcServer   *grpc.Server
+	sbmServer    *grpcServer
 	portForward  *portforward.PortForward
 	shutdownCh   chan struct{}
 
@@ -99,9 +100,9 @@ func (m *sandboxManager) Run(ctx context.Context) error {
 	}
 
 	// Register our service in gRPC server
-	sbmSrv := newSandboxManagerGRPCServer(m.localdConfig.ConnectInvocationConfig,
+	m.sbmServer = newSandboxManagerGRPCServer(m.localdConfig.ConnectInvocationConfig,
 		m.portForward, m.isSBManagerReady, m.getSBMonitor, m.log, m.shutdownCh)
-	sbapi.RegisterSandboxManagerAPIServer(m.grpcServer, sbmSrv)
+	sbapi.RegisterSandboxManagerAPIServer(m.grpcServer, m.sbmServer)
 
 	// Run the gRPC server
 	if err := m.runAPIServer(); err != nil {
@@ -132,6 +133,7 @@ func (m *sandboxManager) Run(ctx context.Context) error {
 	// Clean up
 	m.log.Info("Shutting down")
 	m.grpcServer.GracefulStop()
+	m.sbmServer.stop()
 	if m.portForward != nil {
 		m.portForward.Close()
 	}


### PR DESCRIPTION
This PR includes:

1. https://github.com/signadot/cli/pull/65
2. When re-applying one sandbox it took about 10 seconds for the sanbox to be ready (this is related to closing the established tunnels during the update process).
3. Graceful termination of established tunnels during `local disconnect`.