### PR TITLE
do not update reverse tunnels unless there is a corresponding spec change.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/nsf/jsondiff v0.0.0-20210926074059-1e845ec5d249
 	github.com/signadot/go-sdk v0.3.8-0.20230629093216-a080b761faca
-	github.com/signadot/libconnect v0.1.1-0.20230713155953-1b28070818a7
+	github.com/signadot/libconnect v0.1.1-0.20230714174348-d1651c8dcad6
 	github.com/spf13/cobra v1.6.0
 	github.com/spf13/viper v1.11.0
 	github.com/theckman/yacspin v0.13.12

--- a/go.sum
+++ b/go.sum
@@ -331,8 +331,8 @@ github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZV
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/signadot/go-sdk v0.3.8-0.20230629093216-a080b761faca h1:0LFuVy9H3JC26qUPfJSRHfDMTasgMoQqaIH7RW/D7TM=
 github.com/signadot/go-sdk v0.3.8-0.20230629093216-a080b761faca/go.mod h1:p6ntIt1py1DoLJdtR4DQCVAg+FzHyTgmK6CTaUtnV3w=
-github.com/signadot/libconnect v0.1.1-0.20230713155953-1b28070818a7 h1:3VMoOwTgivx89ehT6Vu2TVBqUaRko68P1rDhtE5LczA=
-github.com/signadot/libconnect v0.1.1-0.20230713155953-1b28070818a7/go.mod h1:E6ExZIKzVtccOHRZxc11OiDnB0/s6ecSjs8Y+STjWL8=
+github.com/signadot/libconnect v0.1.1-0.20230714174348-d1651c8dcad6 h1:N0x9DtdomBFEo6oUiN7T7w8RrrRX8GmRFbXWOZEXrR4=
+github.com/signadot/libconnect v0.1.1-0.20230714174348-d1651c8dcad6/go.mod h1:E6ExZIKzVtccOHRZxc11OiDnB0/s6ecSjs8Y+STjWL8=
 github.com/sirupsen/logrus v1.4.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=


### PR DESCRIPTION
This has been tested locally against https://github.com/signadot/signadot/pull/3465 and also against the operator in staging without the above changes.  In the latter case, we still observe the delay mentioned in https://github.com/signadot/cli/pull/66#issue-1805317944 . In the former case, there is no delay and substantive updates resolved quickly.  This is the expected resulting behaviour,  and related to https://github.com/signadot/cli/pull/66#discussion_r1265084728

