### PR TITLE
Addition of the --root-manager and  --sandbox-manager flags to locald

### DIFF
--- a/internal/config/locald.go
+++ b/internal/config/locald.go
@@ -24,7 +24,9 @@ type LocalDaemon struct {
 	ConnectInvocationConfig *ConnectInvocationConfig
 
 	// Flags
-	DaemonRun bool
+	DaemonRun      bool
+	RootManager    bool
+	SandboxManager bool
 
 	// Hidden Flags
 	ConnectInvocationConfigFile string
@@ -70,7 +72,6 @@ func (ld *LocalDaemon) InitLocalDaemon() error {
 // be passed without plumbing the command line
 type ConnectInvocationConfig struct {
 	WithRootManager  bool                         `json:"withRootManager"`
-	Unprivileged     bool                         `json:"unprivileged"`
 	APIPort          uint16                       `json:"apiPort"`
 	LocalNetPort     uint16                       `json:"localNetPort"`
 	SignadotDir      string                       `json:"signadotDir"`
@@ -84,15 +85,15 @@ type ConnectInvocationConfig struct {
 	Debug            bool                         `json:"debug"`
 }
 
-func (ciConfig *ConnectInvocationConfig) GetPIDfile() string {
-	if !ciConfig.Unprivileged {
+func (ciConfig *ConnectInvocationConfig) GetPIDfile(isRootManager bool) string {
+	if isRootManager {
 		return filepath.Join(ciConfig.SignadotDir, RootManagerPIDFile)
 	}
 	return filepath.Join(ciConfig.SignadotDir, SandboxManagerPIDFile)
 }
 
-func (ciConfig *ConnectInvocationConfig) GetLogName() string {
-	if !ciConfig.Unprivileged {
+func (ciConfig *ConnectInvocationConfig) GetLogName(isRootManager bool) string {
+	if isRootManager {
 		return RootManagerLogFile
 	}
 	return SandboxManagerLogFile
@@ -100,6 +101,8 @@ func (ciConfig *ConnectInvocationConfig) GetLogName() string {
 
 func (c *LocalDaemon) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&c.DaemonRun, "daemon", false, "run in background as daemon")
+	cmd.Flags().BoolVar(&c.RootManager, "root-manager", false, "run the root-manager (privileged daemon)")
+	cmd.Flags().BoolVar(&c.SandboxManager, "sandbox-manager", false, "run the sandbox-manager (unprivileged daemon)")
 
 	cmd.Flags().StringVar(&c.ConnectInvocationConfigFile, "ci-config-file", "", "by-pass calling signadot local connect (hidden)")
 	cmd.Flags().MarkHidden("ci-config-file")

--- a/internal/locald/rootmanager/root_manager.go
+++ b/internal/locald/rootmanager/root_manager.go
@@ -39,10 +39,6 @@ func NewRootManager(cfg *config.LocalDaemon, args []string, log *slog.Logger) (*
 	rootapi.RegisterRootManagerAPIServer(grpcServer, root)
 
 	ciConfig := cfg.ConnectInvocationConfig
-	// make a local copy
-	sbConfig := *ciConfig
-	sbConfig.Unprivileged = true
-
 	log = log.With("locald-component", "root-manager")
 
 	return &rootManager{
@@ -50,7 +46,7 @@ func NewRootManager(cfg *config.LocalDaemon, args []string, log *slog.Logger) (*
 		conf:       cfg.ConnectInvocationConfig,
 		grpcServer: grpcServer,
 		root:       root,
-		sbmMonitor: newSBMgrMonitor(&sbConfig, log),
+		sbmMonitor: newSBMgrMonitor(ciConfig, log),
 		shutdownCh: shutdownCh,
 	}, nil
 }

--- a/internal/locald/rootmanager/sbmgr_monitor.go
+++ b/internal/locald/rootmanager/sbmgr_monitor.go
@@ -31,7 +31,7 @@ func newSBMgrMonitor(ciConfig *config.ConnectInvocationConfig, log *slog.Logger)
 	res := &sbmgrMonitor{
 		ciConfig: ciConfig,
 		log:      log,
-		pidFile:  ciConfig.GetPIDfile(),
+		pidFile:  ciConfig.GetPIDfile(false),
 		done:     make(chan struct{}),
 		doneAck:  make(chan struct{}),
 	}
@@ -52,6 +52,7 @@ func (mon *sbmgrMonitor) getRunSandboxCmd(ciConfig *config.ConnectInvocationConf
 		os.Args[0],
 		"locald",
 		"--daemon",
+		"--sandbox-manager",
 	)
 	cmd.Env = append(cmd.Env,
 		fmt.Sprintf("HOME=%s", ciConfig.UIDHome),

--- a/internal/locald/run.go
+++ b/internal/locald/run.go
@@ -22,7 +22,7 @@ func RunSandboxManager(cfg *config.LocalDaemon, log *slog.Logger, args []string)
 	return sbMgr.Run(ctx)
 }
 
-func RunAsRoot(cfg *config.LocalDaemon, log *slog.Logger, args []string) error {
+func RunRootManager(cfg *config.LocalDaemon, log *slog.Logger, args []string) error {
 	if os.Geteuid() != 0 {
 		return fmt.Errorf("must run as root without --unprivileged")
 	}


### PR DESCRIPTION
As part of this change, I took away `ConnectInvocationConfig.Unprivileged` which was something specific to the `locald` instance rather than to the whole run.

After connected you will find the following processes:

```bash
$ ps ax | grep "signadot local"
1270041 ?        Sl     0:00 ./signadot locald --root-manager
1270096 ?        Sl     0:00 ./signadot locald --sandbox-manager
```
