### PR TITLE
check sb cluster matches connected cluster

### DIFF
--- a/internal/locald/sandboxmanager/sandbox_server.go
+++ b/internal/locald/sandboxmanager/sandbox_server.go
@@ -71,6 +71,12 @@ func (s *sbmServer) ApplySandbox(ctx context.Context, req *sbapi.ApplySandboxReq
 	sb := &models.Sandbox{
 		Spec: sbSpec,
 	}
+	if sbSpec.Cluster == nil {
+		return nil, status.Errorf(codes.Internal, "sandbox spec must specify cluster")
+	}
+	if *sbSpec.Cluster != s.ciConfig.ConnectionConfig.Cluster {
+		return nil, status.Errorf(codes.Internal, "sandbox spec cluster %q does not match connected cluster (%q)", *sbSpec.Cluster, s.ciConfig.ConnectionConfig.Cluster)
+	}
 
 	apiConfig := s.ciConfig.API
 	s.log.Debug("api", "config", apiConfig)


### PR DESCRIPTION
Here's the current error output
```
23-07-18 scott@air cli % ./signadot sandbox apply -f local-sb.yaml --set cluster=air
Error: unable to apply sandbox in sandboxmanager: rpc error: code = Internal desc = sandbox spec cluster "air" does not match connected cluster ("signadot-staging")
```

Closes #73 
