### PR TITLE
Remove strong kubectx dependency & improve status

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/nsf/jsondiff v0.0.0-20210926074059-1e845ec5d249
 	github.com/signadot/go-sdk v0.3.8-0.20230629093216-a080b761faca
-	github.com/signadot/libconnect v0.1.1-0.20230714174348-d1651c8dcad6
+	github.com/signadot/libconnect v0.1.1-0.20230718153815-f9abc7165dd6
 	github.com/spf13/cobra v1.6.0
 	github.com/spf13/viper v1.11.0
 	github.com/theckman/yacspin v0.13.12

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/nsf/jsondiff v0.0.0-20210926074059-1e845ec5d249
 	github.com/signadot/go-sdk v0.3.8-0.20230629093216-a080b761faca
-	github.com/signadot/libconnect v0.1.1-0.20230718153815-f9abc7165dd6
+	github.com/signadot/libconnect v0.1.1-0.20230718181052-aa93718cb097
 	github.com/spf13/cobra v1.6.0
 	github.com/spf13/viper v1.11.0
 	github.com/theckman/yacspin v0.13.12

--- a/go.sum
+++ b/go.sum
@@ -331,8 +331,8 @@ github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZV
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/signadot/go-sdk v0.3.8-0.20230629093216-a080b761faca h1:0LFuVy9H3JC26qUPfJSRHfDMTasgMoQqaIH7RW/D7TM=
 github.com/signadot/go-sdk v0.3.8-0.20230629093216-a080b761faca/go.mod h1:p6ntIt1py1DoLJdtR4DQCVAg+FzHyTgmK6CTaUtnV3w=
-github.com/signadot/libconnect v0.1.1-0.20230718153815-f9abc7165dd6 h1:WVb67ltAr1hQW4F+iftyi0OKSYT6sCMmkHHvxOQ+t8w=
-github.com/signadot/libconnect v0.1.1-0.20230718153815-f9abc7165dd6/go.mod h1:E6ExZIKzVtccOHRZxc11OiDnB0/s6ecSjs8Y+STjWL8=
+github.com/signadot/libconnect v0.1.1-0.20230718181052-aa93718cb097 h1:sY9WSgiTyDXnhb//DY+n1a6jtYnBfGEgcMTCvr1QpU0=
+github.com/signadot/libconnect v0.1.1-0.20230718181052-aa93718cb097/go.mod h1:E6ExZIKzVtccOHRZxc11OiDnB0/s6ecSjs8Y+STjWL8=
 github.com/sirupsen/logrus v1.4.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=

--- a/go.sum
+++ b/go.sum
@@ -331,8 +331,8 @@ github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZV
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/signadot/go-sdk v0.3.8-0.20230629093216-a080b761faca h1:0LFuVy9H3JC26qUPfJSRHfDMTasgMoQqaIH7RW/D7TM=
 github.com/signadot/go-sdk v0.3.8-0.20230629093216-a080b761faca/go.mod h1:p6ntIt1py1DoLJdtR4DQCVAg+FzHyTgmK6CTaUtnV3w=
-github.com/signadot/libconnect v0.1.1-0.20230714174348-d1651c8dcad6 h1:N0x9DtdomBFEo6oUiN7T7w8RrrRX8GmRFbXWOZEXrR4=
-github.com/signadot/libconnect v0.1.1-0.20230714174348-d1651c8dcad6/go.mod h1:E6ExZIKzVtccOHRZxc11OiDnB0/s6ecSjs8Y+STjWL8=
+github.com/signadot/libconnect v0.1.1-0.20230718153815-f9abc7165dd6 h1:WVb67ltAr1hQW4F+iftyi0OKSYT6sCMmkHHvxOQ+t8w=
+github.com/signadot/libconnect v0.1.1-0.20230718153815-f9abc7165dd6/go.mod h1:E6ExZIKzVtccOHRZxc11OiDnB0/s6ecSjs8Y+STjWL8=
 github.com/sirupsen/logrus v1.4.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=

--- a/internal/command/local/connect.go
+++ b/internal/command/local/connect.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"os/user"
 	"path/filepath"
 
 	"github.com/fatih/color"
@@ -55,8 +56,8 @@ func runConnect(cmd *cobra.Command, out io.Writer, cfg *config.LocalConnect, arg
 		return err
 	}
 
-	// Get home dir
-	homeDir, err := os.UserHomeDir()
+	// Resolve the user
+	user, err := user.Current()
 	if err != nil {
 		return err
 	}
@@ -69,14 +70,17 @@ func runConnect(cmd *cobra.Command, out io.Writer, cfg *config.LocalConnect, arg
 
 	// compute ConnectInvocationConfig
 	ciConfig := &config.ConnectInvocationConfig{
-		WithRootManager:  !cfg.Unprivileged,
-		SignadotDir:      signadotDir,
-		APIPort:          6666,
-		LocalNetPort:     6667,
-		UID:              os.Geteuid(),
-		GID:              os.Getegid(),
-		UIDHome:          homeDir,
-		UIDPath:          os.Getenv("PATH"),
+		WithRootManager: !cfg.Unprivileged,
+		SignadotDir:     signadotDir,
+		APIPort:         6666,
+		LocalNetPort:    6667,
+		User: &config.ConnectInvocationUser{
+			UID:      os.Geteuid(),
+			GID:      os.Getegid(),
+			UIDHome:  user.HomeDir,
+			UIDPath:  os.Getenv("PATH"),
+			Username: user.Username,
+		},
 		ConnectionConfig: connConfig,
 		API:              cfg.API,
 		APIKey:           viper.GetString("api_key"),
@@ -142,8 +146,8 @@ func runConnectImpl(out io.Writer, log *slog.Logger, ciConfig *config.ConnectInv
 			"--sandbox-manager",
 		)
 		cmd.Env = append(cmd.Env,
-			fmt.Sprintf("HOME=%s", ciConfig.UIDHome),
-			fmt.Sprintf("PATH=%s", ciConfig.UIDPath),
+			fmt.Sprintf("HOME=%s", ciConfig.User.UIDHome),
+			fmt.Sprintf("PATH=%s", ciConfig.User.UIDPath),
 		)
 	}
 	cmd.Env = append(cmd.Env,
@@ -167,8 +171,8 @@ func getLogger(ciConfig *config.ConnectInvocationConfig) (*slog.Logger, error) {
 	logWriter, _, err := system.GetRollingLogWriter(
 		ciConfig.SignadotDir,
 		ciConfig.GetLogName(ciConfig.WithRootManager),
-		ciConfig.UID,
-		ciConfig.GID,
+		ciConfig.User.UID,
+		ciConfig.User.GID,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't open logfile, %w", err)

--- a/internal/command/local/printers.go
+++ b/internal/command/local/printers.go
@@ -17,26 +17,35 @@ func printRawStatus(out io.Writer, printer func(out io.Writer, v any) error, sta
 		return fmt.Errorf("couldn't unmarshal ci-config from sandbox manager status, %v", err)
 	}
 
+	type PrintableUser struct {
+		UID      int
+		GID      int
+		Username string
+		UIDHome  string
+	}
+
 	type PrintableCiConfig struct {
 		WithRootManager  bool
 		APIPort          uint16
 		LocalNetPort     uint16
 		SignadotDir      string
-		UID              int
-		GID              int
-		UIDHome          string
+		User             *PrintableUser
 		ConnectionConfig *connectcfg.ConnectionConfig
 		API              *config.API
 		Debug            bool
 	}
+
 	ciConfigForPrint := &PrintableCiConfig{
-		WithRootManager:  ciConfig.WithRootManager,
-		APIPort:          ciConfig.APIPort,
-		LocalNetPort:     ciConfig.LocalNetPort,
-		SignadotDir:      ciConfig.SignadotDir,
-		UID:              ciConfig.UID,
-		GID:              ciConfig.GID,
-		UIDHome:          ciConfig.UIDHome,
+		WithRootManager: ciConfig.WithRootManager,
+		APIPort:         ciConfig.APIPort,
+		LocalNetPort:    ciConfig.LocalNetPort,
+		SignadotDir:     ciConfig.SignadotDir,
+		User: &PrintableUser{
+			UID:      ciConfig.User.UID,
+			GID:      ciConfig.User.GID,
+			Username: ciConfig.User.Username,
+			UIDHome:  ciConfig.User.UIDHome,
+		},
 		ConnectionConfig: ciConfig.ConnectionConfig,
 		API:              ciConfig.API,
 		Debug:            ciConfig.Debug,

--- a/internal/command/local/printers.go
+++ b/internal/command/local/printers.go
@@ -11,62 +11,230 @@ import (
 	connectcfg "github.com/signadot/libconnect/config"
 )
 
-func printRawStatus(out io.Writer, printer func(out io.Writer, v any) error, status *sbmapi.StatusResponse) error {
+func printRawStatus(cfg *config.LocalStatus, out io.Writer, printer func(out io.Writer, v any) error,
+	status *sbmapi.StatusResponse) error {
+	// unmarshal the ci config
 	ciConfig, err := sbmapi.ToCIConfig(status.CiConfig)
 	if err != nil {
 		return fmt.Errorf("couldn't unmarshal ci-config from sandbox manager status, %v", err)
 	}
 
-	type PrintableUser struct {
-		UID      int
-		GID      int
-		Username string
-		UIDHome  string
-	}
-
-	type PrintableCiConfig struct {
-		WithRootManager  bool
-		APIPort          uint16
-		LocalNetPort     uint16
-		SignadotDir      string
-		User             *PrintableUser
-		ConnectionConfig *connectcfg.ConnectionConfig
-		API              *config.API
-		Debug            bool
-	}
-
-	ciConfigForPrint := &PrintableCiConfig{
-		WithRootManager: ciConfig.WithRootManager,
-		APIPort:         ciConfig.APIPort,
-		LocalNetPort:    ciConfig.LocalNetPort,
-		SignadotDir:     ciConfig.SignadotDir,
-		User: &PrintableUser{
-			UID:      ciConfig.User.UID,
-			GID:      ciConfig.User.GID,
-			Username: ciConfig.User.Username,
-			UIDHome:  ciConfig.User.UIDHome,
-		},
-		ConnectionConfig: ciConfig.ConnectionConfig,
-		API:              ciConfig.API,
-		Debug:            ciConfig.Debug,
+	// convert the status into a map (useful to convert snake-case fields to camel-case,
+	// format dates, etc)
+	statusMap, err := sbmapi.StatusToMap(status)
+	if err != nil {
+		return err
 	}
 
 	type rawStatus struct {
-		CiConfig    *PrintableCiConfig           `json:"ciConfig,omitempty"`
-		Localnet    *commonapi.LocalNetStatus    `json:"localnet,omitempty"`
-		Hosts       *commonapi.HostsStatus       `json:"hosts,omitempty"`
-		Portforward *commonapi.PortForwardStatus `json:"portforward,omitempty"`
-		Sandboxes   []*commonapi.SandboxStatus   `json:"sandboxes,omitempty"`
+		RuntimeConfig any `json:"runtimeConfig,omitempty"`
+		Localnet      any `json:"localnet,omitempty"`
+		Hosts         any `json:"hosts,omitempty"`
+		Portforward   any `json:"portforward,omitempty"`
+		Sandboxes     any `json:"sandboxes,omitempty"`
 	}
 
 	rawSt := rawStatus{
-		CiConfig:    ciConfigForPrint,
-		Localnet:    status.Localnet,
-		Hosts:       status.Hosts,
-		Portforward: status.Portforward,
-		Sandboxes:   status.Sandboxes,
+		RuntimeConfig: getRawRuntimeConfig(cfg, ciConfig),
+		Localnet:      getRawLocalnet(cfg, ciConfig, status.Localnet, statusMap),
+		Hosts:         getRawHosts(cfg, ciConfig, status.Hosts, statusMap),
+		Portforward:   getRawPortforward(cfg, ciConfig, status.Portforward, statusMap),
+		Sandboxes:     statusMap["sandboxes"],
 	}
+
 	return printer(out, rawSt)
+}
+
+func getRawRuntimeConfig(cfg *config.LocalStatus, ciConfig *config.ConnectInvocationConfig) any {
+	var runtimeConfig any
+
+	if cfg.Details {
+		// Details view
+		type PrintableUser struct {
+			UID      int    `json:"uid"`
+			GID      int    `json:"gid"`
+			Username string `json:"username"`
+			UIDHome  string `json:"uidHome"`
+		}
+
+		type PrintableAPI struct {
+			ConfigFile   string `json:"configFile"`
+			Org          string `json:"org"`
+			MaskedAPIKey string `json:"maskedAPIKey"`
+			APIURL       string `json:"apiURL"`
+		}
+
+		type PrintableRuntimeConfig struct {
+			RootDaemon       bool                         `json:"rootDaemon"`
+			APIPort          uint16                       `json:"apiPort"`
+			LocalNetPort     uint16                       `json:"localNetPort"`
+			ConfigDir        string                       `json:"configDir"`
+			User             *PrintableUser               `json:"user"`
+			ConnectionConfig *connectcfg.ConnectionConfig `json:"connectionConfig"`
+			API              *PrintableAPI                `json:"api"`
+			Debug            bool                         `json:"debug"`
+		}
+
+		runtimeConfig = &PrintableRuntimeConfig{
+			RootDaemon:   ciConfig.WithRootManager,
+			APIPort:      ciConfig.APIPort,
+			LocalNetPort: ciConfig.LocalNetPort,
+			ConfigDir:    ciConfig.SignadotDir,
+			User: &PrintableUser{
+				UID:      ciConfig.User.UID,
+				GID:      ciConfig.User.GID,
+				Username: ciConfig.User.Username,
+				UIDHome:  ciConfig.User.UIDHome,
+			},
+			ConnectionConfig: ciConfig.ConnectionConfig,
+			API: &PrintableAPI{
+				ConfigFile:   ciConfig.API.ConfigFile,
+				Org:          ciConfig.API.Org,
+				MaskedAPIKey: ciConfig.API.MaskedAPIKey,
+				APIURL:       ciConfig.API.APIURL,
+			},
+			Debug: ciConfig.Debug,
+		}
+	} else {
+		// Standard view
+		type PrintableRuntimeConfig struct {
+			RootDaemon       bool                         `json:"rootDaemon"`
+			ConfigDir        string                       `json:"configDir"`
+			ConnectionConfig *connectcfg.ConnectionConfig `json:"connectionConfig"`
+		}
+
+		runtimeConfig = &PrintableRuntimeConfig{
+			RootDaemon:       ciConfig.WithRootManager,
+			ConfigDir:        ciConfig.SignadotDir,
+			ConnectionConfig: ciConfig.ConnectionConfig,
+		}
+	}
+
+	return runtimeConfig
+}
+
+func getRawLocalnet(cfg *config.LocalStatus, ciConfig *config.ConnectInvocationConfig,
+	localnet *commonapi.LocalNetStatus, statusMap map[string]any) any {
+	var result any
+
+	if !ciConfig.WithRootManager {
+		return localnet
+	}
+
+	if cfg.Details {
+		// Details view
+		result = statusMap["localnet"]
+	} else {
+		// Standard view
+		type PrintableLocalnet struct {
+			Healthy         bool   `json:"healthy"`
+			LastErrorReason string `json:"lastErrorReason,omitempty"`
+		}
+
+		result = &PrintableLocalnet{
+			Healthy: false,
+		}
+
+		if localnet != nil {
+			if localnet.Health != nil {
+				if localnet.Health.Healthy {
+					result = &PrintableLocalnet{
+						Healthy: true,
+					}
+				} else {
+					result = &PrintableLocalnet{
+						Healthy:         false,
+						LastErrorReason: localnet.Health.LastErrorReason,
+					}
+				}
+			}
+		}
+	}
+	return result
+}
+
+func getRawHosts(cfg *config.LocalStatus, ciConfig *config.ConnectInvocationConfig,
+	hosts *commonapi.HostsStatus, statusMap map[string]any) any {
+	var result any
+
+	if !ciConfig.WithRootManager {
+		return hosts
+	}
+
+	if cfg.Details {
+		// Details view
+		result = statusMap["hosts"]
+	} else {
+		// Standard view
+		type PrintableHosts struct {
+			Healthy         bool   `json:"healthy"`
+			NumHosts        uint32 `json:"numHosts"`
+			LastErrorReason string `json:"lastErrorReason,omitempty"`
+		}
+
+		result = &PrintableHosts{
+			Healthy: false,
+		}
+
+		if hosts != nil {
+			if hosts.Health != nil {
+				if hosts.Health.Healthy {
+					result = &PrintableHosts{
+						Healthy:  true,
+						NumHosts: hosts.NumHosts,
+					}
+				} else {
+					result = &PrintableHosts{
+						Healthy:         false,
+						LastErrorReason: hosts.Health.LastErrorReason,
+					}
+				}
+			}
+		}
+	}
+	return result
+}
+
+func getRawPortforward(cfg *config.LocalStatus, ciConfig *config.ConnectInvocationConfig,
+	portforward *commonapi.PortForwardStatus, statusMap map[string]any) any {
+	var result any
+
+	if ciConfig.ConnectionConfig.Type != connectcfg.PortForwardLinkType {
+		return portforward
+	}
+
+	if cfg.Details {
+		// Details view
+		result = statusMap["portforward"]
+	} else {
+		// Standard view
+		type PrintablePortforward struct {
+			Healthy         bool   `json:"healthy"`
+			LocalAddress    string `json:"localAddress"`
+			LastErrorReason string `json:"lastErrorReason,omitempty"`
+		}
+
+		result = &PrintablePortforward{
+			Healthy: false,
+		}
+
+		if portforward != nil {
+			if portforward.Health != nil {
+				if portforward.Health.Healthy {
+					result = &PrintablePortforward{
+						Healthy:      true,
+						LocalAddress: portforward.LocalAddress,
+					}
+				} else {
+					result = &PrintablePortforward{
+						Healthy:         false,
+						LastErrorReason: portforward.Health.LastErrorReason,
+					}
+				}
+			}
+		}
+	}
+	return result
 }
 
 func printLocalStatus(cfg *config.LocalStatus, out io.Writer, status *sbmapi.StatusResponse) error {
@@ -74,127 +242,195 @@ func printLocalStatus(cfg *config.LocalStatus, out io.Writer, status *sbmapi.Sta
 	if err != nil {
 		return fmt.Errorf("couldn't unmarshal ci-config from sandbox manager status, %v", err)
 	}
-
 	errorLines := []string{}
-	healthyLines := []string{}
 
 	// check port forward status
 	if ciConfig.ConnectionConfig.Type == connectcfg.PortForwardLinkType {
-		msg, ok := checkPortforwardStatus(status.Portforward)
-		if ok {
-			healthyLines = append(healthyLines, msg)
-		} else {
-			errorLines = append(errorLines, msg)
+		err := checkPortforwardStatus(status.Portforward)
+		if err != nil {
+			errorLines = append(errorLines, err.Error())
 		}
 	}
-
 	// check root manager (if running)
 	if ciConfig.WithRootManager {
 		// check localnet service
-		msg, ok := checkLocalNetStatus(status.Localnet)
-		if ok {
-			healthyLines = append(healthyLines, msg)
-		} else {
-			errorLines = append(errorLines, msg)
+		err := checkLocalNetStatus(status.Localnet)
+		if err != nil {
+			errorLines = append(errorLines, err.Error())
 		}
-
 		// check hosts service
-		msg, ok = checkHostsStatus(status.Hosts)
-		if ok {
-			healthyLines = append(healthyLines, msg)
-		} else {
-			errorLines = append(errorLines, msg)
+		err = checkHostsStatus(status.Hosts)
+		if err != nil {
+			errorLines = append(errorLines, err.Error())
 		}
 	}
 
-	green := color.New(color.FgGreen).SprintFunc()
-	red := color.New(color.FgRed).SprintFunc()
-	white := color.New(color.FgHiWhite, color.Bold).SprintFunc()
-
+	// create a printer
+	printer := statusPrinter{
+		cfg:      cfg,
+		status:   status,
+		ciConfig: ciConfig,
+		out:      out,
+		green:    color.New(color.FgGreen).SprintFunc(),
+		red:      color.New(color.FgRed).SprintFunc(),
+		white:    color.New(color.FgHiWhite, color.Bold).SprintFunc(),
+	}
+	// runtime config
+	printer.printRuntimeConfig()
+	// print status
 	if len(errorLines) == 0 {
-		printLine(out, 0, fmt.Sprintf("connection healthy! %s", green("✓")), "*")
-		for _, line := range healthyLines {
-			printLine(out, 0, line, "*")
-		}
-		printLine(out, 0, "Local Sandboxes:", "*")
-		if len(status.Sandboxes) == 0 {
-			printLine(out, 1, "No active sandbox", "-")
-		} else {
-			for _, sandbox := range status.Sandboxes {
-				printLine(out, 1, white(sandbox.Name), "-")
-				printLine(out, 2, fmt.Sprintf("Routing Key: %s", sandbox.RoutingKey), "*")
-				printLine(out, 2, "Local Workloads:", "*")
-				for _, localwl := range sandbox.LocalWorkloads {
-					printLine(out, 3, white(localwl.Name), "-")
-					printLine(out, 4, fmt.Sprintf("%s/%s in namespace %q",
-						localwl.Baseline.Kind, localwl.Baseline.Name, localwl.Baseline.Namespace), "*")
-					for _, portMap := range localwl.WorkloadPortMapping {
-						printLine(out, 5, fmt.Sprintf("port %d -> %s",
-							portMap.BaselinePort, portMap.LocalAddress), "*")
-					}
-					if localwl.TunnelHealth.Healthy {
-						printLine(out, 4, fmt.Sprintf("workload connected! %s", green("✓")), "*")
-					} else {
-						printLine(out, 4, fmt.Sprintf("workload not yet connected! %s", red("✗")), "*")
-					}
-				}
-			}
-		}
+		printer.printSuccess()
 	} else {
-		printLine(out, 0, fmt.Sprintf("connection not healthy! %s", red("✗")), "*")
-		for _, line := range errorLines {
-			printLine(out, 0, line, "*")
-		}
+		printer.printErrors(errorLines)
 	}
 	return nil
 }
 
-func checkPortforwardStatus(portforward *commonapi.PortForwardStatus) (string, bool) {
+func checkPortforwardStatus(portforward *commonapi.PortForwardStatus) error {
 	errorMsg := "failed to establish port-forward"
 	if portforward != nil {
 		if portforward.Health != nil {
 			if portforward.Health.Healthy {
-				return fmt.Sprintf("port-forward listening at %q", portforward.LocalAddress), true
+				return nil
 			}
 			if portforward.Health.LastErrorReason != "" {
 				errorMsg += fmt.Sprintf(" (%q)", portforward.Health.LastErrorReason)
 			}
 		}
 	}
-	return errorMsg, false
+	return fmt.Errorf(errorMsg)
 }
 
-func checkLocalNetStatus(localnet *commonapi.LocalNetStatus) (string, bool) {
+func checkLocalNetStatus(localnet *commonapi.LocalNetStatus) error {
 	errorMsg := "failed to setup localnet"
 	if localnet != nil {
 		if localnet.Health != nil {
 			if localnet.Health.Healthy {
-				return "localnet has been configured", true
+				return nil
 			}
 			if localnet.Health.LastErrorReason != "" {
 				errorMsg += fmt.Sprintf(" (%q)", localnet.Health.LastErrorReason)
 			}
 		}
 	}
-	return errorMsg, false
+	return fmt.Errorf(errorMsg)
 }
 
-func checkHostsStatus(hosts *commonapi.HostsStatus) (string, bool) {
+func checkHostsStatus(hosts *commonapi.HostsStatus) error {
 	errorMsg := "failed to configure hosts in /etc/hosts"
 	if hosts != nil {
 		if hosts.Health != nil {
 			if hosts.Health.Healthy {
-				return fmt.Sprintf("%d hosts accessible via /etc/hosts", hosts.NumHosts), true
+				return nil
 			}
 			if hosts.Health.LastErrorReason != "" {
 				errorMsg += fmt.Sprintf(" (%q)", hosts.Health.LastErrorReason)
 			}
 		}
 	}
-	return errorMsg, false
+	return fmt.Errorf(errorMsg)
 }
 
-func printLine(out io.Writer, idents int, line, prefix string) {
+type statusPrinter struct {
+	cfg      *config.LocalStatus
+	status   *sbmapi.StatusResponse
+	ciConfig *config.ConnectInvocationConfig
+	out      io.Writer
+	green    func(a ...any) string
+	red      func(a ...any) string
+	white    func(a ...any) string
+}
+
+func (p *statusPrinter) printRuntimeConfig() {
+	var runtimeConfig string
+	if p.ciConfig.WithRootManager {
+		runtimeConfig = fmt.Sprintf("runtime config: cluster %s, running with root-daemon",
+			p.white(p.ciConfig.ConnectionConfig.Cluster))
+	} else {
+		runtimeConfig = fmt.Sprintf("runtime config: cluster %s, running without root-daemon",
+			p.white(p.ciConfig.ConnectionConfig.Cluster))
+	}
+	if p.cfg.Details {
+		runtimeConfig += fmt.Sprintf(" (config-dir: %s)", p.ciConfig.SignadotDir)
+	}
+	p.printLine(p.out, 0, runtimeConfig, "*")
+}
+
+func (p *statusPrinter) printErrors(errorLines []string) {
+	p.printLine(p.out, 0, fmt.Sprintf("connection not healthy! %s", p.red("✗")), "*")
+	for _, line := range errorLines {
+		p.printLine(p.out, 0, line, "*")
+	}
+}
+
+func (p *statusPrinter) printSuccess() {
+	p.printLine(p.out, 0, fmt.Sprintf("connection healthy! %s", p.green("✓")), "*")
+	if p.ciConfig.ConnectionConfig.Type == connectcfg.PortForwardLinkType {
+		p.printPortforwardStatus()
+	}
+	if p.ciConfig.WithRootManager {
+		p.printLocalnetStatus()
+		p.printHostsStatus()
+	}
+	p.printSandboxStatus()
+}
+
+func (p *statusPrinter) printPortforwardStatus() {
+	p.printLine(p.out, 0, fmt.Sprintf("port-forward listening at %q", p.status.Portforward.LocalAddress), "*")
+}
+
+func (p *statusPrinter) printLocalnetStatus() {
+	if p.cfg.Details {
+		p.printLine(p.out, 0, "localnet has been configured", "*")
+		if len(p.status.Localnet.Cidrs) > 0 {
+			p.printLine(p.out, 1, "CIDRs:", "*")
+			for _, cidr := range p.status.Localnet.Cidrs {
+				p.printLine(p.out, 2, cidr, "-")
+			}
+		}
+		if len(p.status.Localnet.ExcludedCidrs) > 0 {
+			p.printLine(p.out, 1, "Excluded CIDRs:", "*")
+			for _, cidr := range p.status.Localnet.ExcludedCidrs {
+				p.printLine(p.out, 2, cidr, "-")
+			}
+		}
+	} else {
+		p.printLine(p.out, 0, "localnet has been configured", "*")
+	}
+}
+
+func (p *statusPrinter) printHostsStatus() {
+	p.printLine(p.out, 0, fmt.Sprintf("%d hosts accessible via /etc/hosts", p.status.Hosts.NumHosts), "*")
+}
+
+func (p *statusPrinter) printSandboxStatus() {
+	p.printLine(p.out, 0, "Local Sandboxes:", "*")
+	if len(p.status.Sandboxes) == 0 {
+		p.printLine(p.out, 1, "No active sandbox", "-")
+	} else {
+		for _, sandbox := range p.status.Sandboxes {
+			p.printLine(p.out, 1, p.white(sandbox.Name), "-")
+			p.printLine(p.out, 2, fmt.Sprintf("Routing Key: %s", sandbox.RoutingKey), "*")
+			p.printLine(p.out, 2, "Local Workloads:", "*")
+			for _, localwl := range sandbox.LocalWorkloads {
+				p.printLine(p.out, 3, p.white(localwl.Name), "-")
+				p.printLine(p.out, 4, fmt.Sprintf("%s/%s in namespace %q",
+					localwl.Baseline.Kind, localwl.Baseline.Name, localwl.Baseline.Namespace), "*")
+				for _, portMap := range localwl.WorkloadPortMapping {
+					p.printLine(p.out, 5, fmt.Sprintf("port %d -> %s",
+						portMap.BaselinePort, portMap.LocalAddress), "*")
+				}
+				if localwl.TunnelHealth.Healthy {
+					p.printLine(p.out, 4, fmt.Sprintf("workload connected! %s", p.green("✓")), "*")
+				} else {
+					p.printLine(p.out, 4, fmt.Sprintf("workload not yet connected! %s", p.red("✗")), "*")
+				}
+			}
+		}
+	}
+}
+
+func (p *statusPrinter) printLine(out io.Writer, idents int, line, prefix string) {
 	for i := 0; i < idents; i++ {
 		fmt.Fprintf(out, "    ")
 	}

--- a/internal/command/local/status.go
+++ b/internal/command/local/status.go
@@ -26,6 +26,7 @@ func newStatus(localConfig *config.Local) *cobra.Command {
 			return runStatus(cfg, cmd.OutOrStdout(), args)
 		},
 	}
+	cfg.AddFlags(cmd)
 
 	return cmd
 }
@@ -68,9 +69,9 @@ func runStatus(cfg *config.LocalStatus, out io.Writer, args []string) error {
 	case config.OutputFormatDefault:
 		return printLocalStatus(cfg, out, status)
 	case config.OutputFormatJSON:
-		return printRawStatus(out, print.RawJSON, status)
+		return printRawStatus(cfg, out, print.RawJSON, status)
 	case config.OutputFormatYAML:
-		return printRawStatus(out, print.RawYAML, status)
+		return printRawStatus(cfg, out, print.RawYAML, status)
 	default:
 		return fmt.Errorf("unsupported output format: %q", cfg.OutputFormat)
 	}

--- a/internal/command/local/status.go
+++ b/internal/command/local/status.go
@@ -71,7 +71,7 @@ func runStatus(cfg *config.LocalStatus, out io.Writer, args []string) error {
 	case config.OutputFormatJSON:
 		return printRawStatus(cfg, out, print.RawJSON, status)
 	case config.OutputFormatYAML:
-		return printRawStatus(cfg, out, print.RawYAML, status)
+		return printRawStatus(cfg, out, print.RawK8SYAML, status)
 	default:
 		return fmt.Errorf("unsupported output format: %q", cfg.OutputFormat)
 	}

--- a/internal/command/locald/locald.go
+++ b/internal/command/locald/locald.go
@@ -49,8 +49,8 @@ func run(cfg *config.LocalDaemon, args []string) error {
 			cmd = exec.Command(os.Args[0], "locald", "--sandbox-manager")
 		}
 		cmd.Env = append(cmd.Env,
-			fmt.Sprintf("HOME=%s", ciConfig.UIDHome),
-			fmt.Sprintf("PATH=%s", ciConfig.UIDPath),
+			fmt.Sprintf("HOME=%s", ciConfig.User.UIDHome),
+			fmt.Sprintf("PATH=%s", ciConfig.User.UIDPath),
 			fmt.Sprintf("SIGNADOT_LOCAL_CONNECT_INVOCATION_CONFIG=%s",
 				os.Getenv("SIGNADOT_LOCAL_CONNECT_INVOCATION_CONFIG")),
 		)
@@ -66,7 +66,7 @@ func run(cfg *config.LocalDaemon, args []string) error {
 		return err
 	}
 	// make sure pidfile perms are correct
-	if err := os.Chown(pidFile, ciConfig.UID, ciConfig.GID); err != nil {
+	if err := os.Chown(pidFile, ciConfig.User.UID, ciConfig.User.GID); err != nil {
 		log.Warn("couldn't change ownership of pidfile", "error", err)
 	}
 	defer func() {
@@ -84,8 +84,8 @@ func getLogger(ciConfig *config.ConnectInvocationConfig, isRootManager bool) (*s
 	logWriter, _, err := system.GetRollingLogWriter(
 		ciConfig.SignadotDir,
 		ciConfig.GetLogName(isRootManager),
-		ciConfig.UID,
-		ciConfig.GID,
+		ciConfig.User.UID,
+		ciConfig.User.GID,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't open logfile, %w", err)

--- a/internal/command/locald/locald.go
+++ b/internal/command/locald/locald.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"os/signal"
+	"syscall"
 	"time"
 
 	"github.com/signadot/cli/internal/config"
@@ -30,6 +32,8 @@ func New(apiConfig *config.API) *cobra.Command {
 }
 
 func run(cfg *config.LocalDaemon, args []string) error {
+	signal.Ignore(syscall.SIGHUP)
+
 	if err := cfg.InitLocalDaemon(); err != nil {
 		return err
 	}

--- a/internal/config/local.go
+++ b/internal/config/local.go
@@ -95,4 +95,11 @@ type LocalDisconnect struct {
 
 type LocalStatus struct {
 	*Local
+
+	// Flags
+	Details bool
+}
+
+func (c *LocalStatus) AddFlags(cmd *cobra.Command) {
+	cmd.Flags().BoolVar(&c.Details, "details", false, "display status details")
 }

--- a/internal/config/locald.go
+++ b/internal/config/locald.go
@@ -75,14 +75,19 @@ type ConnectInvocationConfig struct {
 	APIPort          uint16                       `json:"apiPort"`
 	LocalNetPort     uint16                       `json:"localNetPort"`
 	SignadotDir      string                       `json:"signadotDir"`
-	UID              int                          `json:"uid"`
-	GID              int                          `json:"gid"`
-	UIDHome          string                       `json:"uidHome"`
-	UIDPath          string                       `json:"uidPath"`
+	User             *ConnectInvocationUser       `json:"user"`
 	ConnectionConfig *connectcfg.ConnectionConfig `json:"connectionConfig"`
 	API              *API                         `json:"api"`
 	APIKey           string                       `json:"apiKey"`
 	Debug            bool                         `json:"debug"`
+}
+
+type ConnectInvocationUser struct {
+	UID      int    `json:"uid"`
+	GID      int    `json:"gid"`
+	UIDHome  string `json:"uidHome"`
+	UIDPath  string `json:"uidPath"`
+	Username string `json:"username"`
 }
 
 func (ciConfig *ConnectInvocationConfig) GetPIDfile(isRootManager bool) string {

--- a/internal/config/root.go
+++ b/internal/config/root.go
@@ -55,7 +55,9 @@ func (c *Root) init() error {
 		}
 	}
 
-	c.Debug = viper.GetBool("debug")
+	if !c.Debug {
+		c.Debug = viper.GetBool("debug")
+	}
 
 	if dashURL := viper.GetString("dashboard_url"); dashURL != "" {
 		u, err := url.Parse(dashURL)

--- a/internal/locald/api/sandboxmanager/convert.go
+++ b/internal/locald/api/sandboxmanager/convert.go
@@ -2,9 +2,11 @@ package sandboxmanager
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/signadot/cli/internal/config"
 	"github.com/signadot/go-sdk/models"
+	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
@@ -70,4 +72,17 @@ func ToCIConfig(grpcSpec *structpb.Struct) (*config.ConnectInvocationConfig, err
 		return nil, err
 	}
 	return ciConfig, nil
+}
+
+func StatusToMap(status *StatusResponse) (map[string]interface{}, error) {
+	statusBytes, err := (protojson.MarshalOptions{}).Marshal(status)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't marshal status, %v", err)
+	}
+	var statusMap map[string]interface{}
+	err = json.Unmarshal(statusBytes, &statusMap)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't unmarshal status, %v", err)
+	}
+	return statusMap, nil
 }

--- a/internal/locald/api/sandboxmanager/convert.go
+++ b/internal/locald/api/sandboxmanager/convert.go
@@ -1,6 +1,7 @@
 package sandboxmanager
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 
@@ -74,14 +75,15 @@ func ToCIConfig(grpcSpec *structpb.Struct) (*config.ConnectInvocationConfig, err
 	return ciConfig, nil
 }
 
-func StatusToMap(status *StatusResponse) (map[string]interface{}, error) {
+func StatusToMap(status *StatusResponse) (map[string]any, error) {
 	statusBytes, err := (protojson.MarshalOptions{}).Marshal(status)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't marshal status, %v", err)
 	}
-	var statusMap map[string]interface{}
-	err = json.Unmarshal(statusBytes, &statusMap)
-	if err != nil {
+	d := json.NewDecoder(bytes.NewReader(statusBytes))
+	d.UseNumber()
+	var statusMap map[string]any
+	if err := d.Decode(&statusMap); err != nil {
 		return nil, fmt.Errorf("couldn't unmarshal status, %v", err)
 	}
 	return statusMap, nil

--- a/internal/locald/rootmanager/pfw_monitor.go
+++ b/internal/locald/rootmanager/pfw_monitor.go
@@ -29,7 +29,7 @@ type pfwMonitor struct {
 func NewPortForwardMonitor(ctx context.Context, root *rootManager) *pfwMonitor {
 	mon := &pfwMonitor{
 		log:           root.log,
-		sbManagerAddr: fmt.Sprintf("127.0.0.1:%d", root.conf.APIPort),
+		sbManagerAddr: fmt.Sprintf("127.0.0.1:%d", root.ciConfig.APIPort),
 		root:          root,
 		starting:      true,
 		closeCh:       make(chan struct{}),

--- a/internal/locald/rootmanager/sbmgr_monitor.go
+++ b/internal/locald/rootmanager/sbmgr_monitor.go
@@ -47,7 +47,7 @@ func (mon *sbmgrMonitor) getRunSandboxCmd(ciConfig *config.ConnectInvocationConf
 	cmd := exec.Command(
 		"sudo",
 		"-n",
-		"-u", fmt.Sprintf("#%d", ciConfig.UID),
+		"-u", fmt.Sprintf("#%d", ciConfig.User.UID),
 		"--preserve-env=SIGNADOT_LOCAL_CONNECT_INVOCATION_CONFIG",
 		os.Args[0],
 		"locald",
@@ -55,8 +55,8 @@ func (mon *sbmgrMonitor) getRunSandboxCmd(ciConfig *config.ConnectInvocationConf
 		"--sandbox-manager",
 	)
 	cmd.Env = append(cmd.Env,
-		fmt.Sprintf("HOME=%s", ciConfig.UIDHome),
-		fmt.Sprintf("PATH=%s", ciConfig.UIDPath),
+		fmt.Sprintf("HOME=%s", ciConfig.User.UIDHome),
+		fmt.Sprintf("PATH=%s", ciConfig.User.UIDPath),
 		fmt.Sprintf("SIGNADOT_LOCAL_CONNECT_INVOCATION_CONFIG=%s", string(ciBytes)),
 	)
 	return cmd

--- a/internal/print/raw.go
+++ b/internal/print/raw.go
@@ -5,6 +5,7 @@ import (
 	"io"
 
 	"github.com/goccy/go-yaml"
+	k8syaml "sigs.k8s.io/yaml"
 )
 
 func RawJSON(out io.Writer, v any) error {
@@ -16,6 +17,15 @@ func RawJSON(out io.Writer, v any) error {
 func RawYAML(out io.Writer, v any) error {
 	opt := yaml.UseLiteralStyleIfMultiline(true)
 	data, err := yaml.MarshalWithOptions(v, opt)
+	if err != nil {
+		return err
+	}
+	_, err = out.Write(data)
+	return err
+}
+
+func RawK8SYAML(out io.Writer, v any) error {
+	data, err := k8syaml.Marshal(v)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
These changes include the removal of the strong kubectx dependency (in the case of LB) and also improve `signadot local status` output (as per the discussion in https://signadot.slack.com/archives/C04ST9XTLTC/p1689624722091039.