### PR TITLE
Local baseline port int

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -100,4 +100,4 @@ require (
 
 // Used for local dev
 //replace github.com/signadot/libconnect => ../libconnect/
-replace github.com/signadot/go-sdk => ../go-sdk
+// replace github.com/signadot/go-sdk => ../go-sdk

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/golang/protobuf v1.5.3
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/nsf/jsondiff v0.0.0-20210926074059-1e845ec5d249
-	github.com/signadot/go-sdk v0.3.8-0.20230629093216-a080b761faca
+	github.com/signadot/go-sdk v0.3.8-0.20230719152350-64caa01ff9f7
 	github.com/signadot/libconnect v0.1.1-0.20230718181052-aa93718cb097
 	github.com/spf13/cobra v1.6.0
 	github.com/spf13/viper v1.11.0
@@ -34,7 +34,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-openapi/analysis v0.21.4 // indirect
 	github.com/go-openapi/errors v0.20.4 // indirect
-	github.com/go-openapi/jsonpointer v0.19.6 // indirect
+	github.com/go-openapi/jsonpointer v0.20.0 // indirect
 	github.com/go-openapi/jsonreference v0.20.2 // indirect
 	github.com/go-openapi/loads v0.21.2 // indirect
 	github.com/go-openapi/spec v0.20.9 // indirect
@@ -100,3 +100,4 @@ require (
 
 // Used for local dev
 //replace github.com/signadot/libconnect => ../libconnect/
+replace github.com/signadot/go-sdk => ../go-sdk

--- a/go.sum
+++ b/go.sum
@@ -330,6 +330,8 @@ github.com/rogpeppe/go-internal v1.2.2/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDNXVBh4M=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/signadot/go-sdk v0.3.8-0.20230719152350-64caa01ff9f7 h1:M2wFXW05iOAzCYg2mVePRPDgceXPsqkUVF4ttic5p8Q=
+github.com/signadot/go-sdk v0.3.8-0.20230719152350-64caa01ff9f7/go.mod h1:DOBc8nMH/5Wu9pDO7xZK52TRhuh2LqvvNi8eli7BG9A=
 github.com/signadot/libconnect v0.1.1-0.20230718181052-aa93718cb097 h1:sY9WSgiTyDXnhb//DY+n1a6jtYnBfGEgcMTCvr1QpU0=
 github.com/signadot/libconnect v0.1.1-0.20230718181052-aa93718cb097/go.mod h1:E6ExZIKzVtccOHRZxc11OiDnB0/s6ecSjs8Y+STjWL8=
 github.com/sirupsen/logrus v1.4.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=

--- a/go.sum
+++ b/go.sum
@@ -94,8 +94,9 @@ github.com/go-openapi/errors v0.20.4 h1:unTcVm6PispJsMECE3zWgvG4xTiKda1LIR5rCRWL
 github.com/go-openapi/errors v0.20.4/go.mod h1:Z3FlZ4I8jEGxjUK+bugx3on2mIAk4txuAOhlsB1FSgk=
 github.com/go-openapi/jsonpointer v0.19.3/go.mod h1:Pl9vOtqEWErmShwVjC8pYs9cog34VGT37dQOVbmoatg=
 github.com/go-openapi/jsonpointer v0.19.5/go.mod h1:Pl9vOtqEWErmShwVjC8pYs9cog34VGT37dQOVbmoatg=
-github.com/go-openapi/jsonpointer v0.19.6 h1:eCs3fxoIi3Wh6vtgmLTOjdhSpiqphQ+DaPn38N2ZdrE=
 github.com/go-openapi/jsonpointer v0.19.6/go.mod h1:osyAmYz/mB/C3I+WsTTSgw1ONzaLJoLCyoi6/zppojs=
+github.com/go-openapi/jsonpointer v0.20.0 h1:ESKJdU9ASRfaPNOPRx12IUyA1vn3R9GiE3KYD14BXdQ=
+github.com/go-openapi/jsonpointer v0.20.0/go.mod h1:6PGzBjjIIumbLYysB73Klnms1mwnU4G3YHOECG3CedA=
 github.com/go-openapi/jsonreference v0.19.6/go.mod h1:diGHMEHg2IqXZGKxqyvWdfWU/aim5Dprw5bqpKkTvns=
 github.com/go-openapi/jsonreference v0.20.0/go.mod h1:Ag74Ico3lPc+zR+qjn4XBUmXymS4zJbYVCZmcgkasdo=
 github.com/go-openapi/jsonreference v0.20.2 h1:3sVjiK66+uXK/6oQ8xgcRKcFgQ5KXa2KvnJRumpMGbE=
@@ -327,10 +328,8 @@ github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJ
 github.com/rogpeppe/go-internal v1.1.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.2.2/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
-github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
+github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDNXVBh4M=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/signadot/go-sdk v0.3.8-0.20230629093216-a080b761faca h1:0LFuVy9H3JC26qUPfJSRHfDMTasgMoQqaIH7RW/D7TM=
-github.com/signadot/go-sdk v0.3.8-0.20230629093216-a080b761faca/go.mod h1:p6ntIt1py1DoLJdtR4DQCVAg+FzHyTgmK6CTaUtnV3w=
 github.com/signadot/libconnect v0.1.1-0.20230718181052-aa93718cb097 h1:sY9WSgiTyDXnhb//DY+n1a6jtYnBfGEgcMTCvr1QpU0=
 github.com/signadot/libconnect v0.1.1-0.20230718181052-aa93718cb097/go.mod h1:E6ExZIKzVtccOHRZxc11OiDnB0/s6ecSjs8Y+STjWL8=
 github.com/sirupsen/logrus v1.4.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
@@ -364,8 +363,8 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/stretchr/testify v1.8.3 h1:RP3t2pwF7cMEbC1dqtB6poj3niw/9gnV4Cjg5oW5gtY=
 github.com/stretchr/testify v1.8.3/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/subosito/gotenv v1.4.2 h1:X1TuBLAMDFbaTAChgCBLu3DU3UPyELpnF2jjJ2cz/S8=
 github.com/subosito/gotenv v1.4.2/go.mod h1:ayKnFf/c6rvx/2iiLrJUk1e6plDbT3edrFNGqEflhK0=
 github.com/theckman/yacspin v0.13.12 h1:CdZ57+n0U6JMuh2xqjnjRq5Haj6v1ner2djtLQRzJr4=

--- a/internal/locald/sandboxmanager/revtun.go
+++ b/internal/locald/sandboxmanager/revtun.go
@@ -39,7 +39,7 @@ func newRevtun(log *slog.Logger, rtc revtun.Client, name, rk string, local *mode
 		rtConfig.Forwards = append(rtConfig.Forwards,
 			rtproto.Forward{
 				LocalURL: fmt.Sprintf("tcp://%s", pm.ToLocal),
-				RemoteURL: fmt.Sprintf("tcp://%s.%s.%s:%s",
+				RemoteURL: fmt.Sprintf("tcp://%s.%s.%s:%d",
 					*local.From.Name,
 					*local.From.Namespace,
 					kind,

--- a/local-sb.yaml
+++ b/local-sb.yaml
@@ -12,7 +12,7 @@ spec:
       namespace: hotrod
       name: route
     mappings:
-    - port: "8083"
+    - port: 8083
       toLocal: "localhost:8083"
   defaultRouteGroup:
     endpoints: 


### PR DESCRIPTION
incorporate local baseline port as int changes.

This uses go-sdk from branch local-baseline-port-int instead of creating a go-sdk PR because that seems weird to publish the go-sdk when it's not in swagger or the other sdks.

