### PR TITLE
local connect --wait and --wait-timeout

### DIFF
--- a/internal/command/local/connect.go
+++ b/internal/command/local/connect.go
@@ -41,6 +41,10 @@ func runConnect(cmd *cobra.Command, out io.Writer, cfg *config.LocalConnect, arg
 		return err
 	}
 
+	if cfg.OutputFormat != config.OutputFormatDefault {
+		return fmt.Errorf("output format %s not supported for connect", cfg.OutputFormat)
+	}
+
 	// we will pass the connConfig to rootmanager and sandboxmanager
 	connConfig, err := cfg.GetConnectionConfig(cfg.Cluster)
 	if err != nil {

--- a/internal/command/local/disconnect.go
+++ b/internal/command/local/disconnect.go
@@ -39,6 +39,10 @@ func runDisconnect(cfg *config.LocalDisconnect, args []string) error {
 	if err != nil {
 		return err
 	}
+	return runDisconnectWith(cfg, signadotDir)
+}
+
+func runDisconnectWith(cfg *config.LocalDisconnect, signadotDir string) error {
 
 	runState := &runState{}
 	ticker := time.NewTicker(time.Second / 10)

--- a/internal/command/local/disconnect.go
+++ b/internal/command/local/disconnect.go
@@ -35,6 +35,9 @@ func runDisconnect(cfg *config.LocalDisconnect, args []string) error {
 	if err := cfg.InitLocalConfig(); err != nil {
 		return err
 	}
+	if cfg.OutputFormat != config.OutputFormatDefault {
+		return fmt.Errorf("output format %s not supported for disconnect", cfg.OutputFormat)
+	}
 	signadotDir, err := system.GetSignadotDir()
 	if err != nil {
 		return err

--- a/internal/command/local/status.go
+++ b/internal/command/local/status.go
@@ -50,17 +50,8 @@ func runStatus(cfg *config.LocalStatus, out io.Writer, args []string) error {
 	if !isRunning {
 		return fmt.Errorf("signadot is not connected\n")
 	}
+	status, err := getStatus()
 
-	// Get a sandbox manager API client
-	grpcConn, err := grpc.Dial("127.0.0.1:6666", grpc.WithTransportCredentials(insecure.NewCredentials()))
-	if err != nil {
-		return fmt.Errorf("couldn't connect sandbox manager api: %w", err)
-	}
-	defer grpcConn.Close()
-
-	// Send the shutdown order
-	sbManagerClient := sbmapi.NewSandboxManagerAPIClient(grpcConn)
-	status, err := sbManagerClient.Status(context.Background(), &sbmapi.StatusRequest{})
 	if err != nil {
 		return fmt.Errorf("couldn't get status from sandbox manager api: %w", err)
 	}
@@ -75,4 +66,21 @@ func runStatus(cfg *config.LocalStatus, out io.Writer, args []string) error {
 	default:
 		return fmt.Errorf("unsupported output format: %q", cfg.OutputFormat)
 	}
+}
+
+func getStatus() (*sbmapi.StatusResponse, error) {
+	// Get a sandbox manager API client
+	grpcConn, err := grpc.Dial("127.0.0.1:6666", grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		return nil, fmt.Errorf("couldn't connect sandbox manager api: %w", err)
+	}
+	defer grpcConn.Close()
+
+	// get the status
+	sbManagerClient := sbmapi.NewSandboxManagerAPIClient(grpcConn)
+	status, err := sbManagerClient.Status(context.Background(), &sbmapi.StatusRequest{})
+	if err != nil {
+		return nil, fmt.Errorf("couldn't get status from sandbox manager api: %w", err)
+	}
+	return status, nil
 }

--- a/internal/config/local.go
+++ b/internal/config/local.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/signadot/libconnect/config"
 	"github.com/spf13/cobra"
@@ -76,6 +77,8 @@ type LocalConnect struct {
 	// Flags
 	Cluster      string
 	Unprivileged bool
+	Wait         bool
+	WaitTimeout  time.Duration
 
 	// Hidden Flags
 	DumpCIConfig bool
@@ -85,6 +88,8 @@ func (c *LocalConnect) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&c.Cluster, "cluster", "", "specify cluster connection config")
 
 	cmd.Flags().BoolVar(&c.Unprivileged, "unprivileged", false, "run without root privileges")
+	cmd.Flags().BoolVar(&c.Wait, "wait", false, "wait for connection healthy")
+	cmd.Flags().DurationVar(&c.WaitTimeout, "wait-timeout", 10*time.Second, "timeout to wait")
 	cmd.Flags().BoolVar(&c.DumpCIConfig, "dump-ci-config", false, "dump connect invocation config")
 	cmd.Flags().MarkHidden("dump-ci-config")
 }


### PR DESCRIPTION
when `--wait` is specified, connect will run until the connection is healthy or `--wait-timeout` is reached.  In the case `--wait-timeout` is reached before the connection is healthy, `signadot local connect --wait` will stop the background processes which are trying and failing to establish the connection and exit with a non-zero exit code.

also, disallow `-o` for `signadot local [dis]connect`, before this PR `-o yaml`, etc was a no-op
