### PR TITLE
Clean local sandboxes on disconnect

### DIFF
--- a/internal/command/local/disconnect.go
+++ b/internal/command/local/disconnect.go
@@ -2,6 +2,7 @@ package local
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -10,7 +11,9 @@ import (
 	"github.com/signadot/cli/internal/config"
 	rmapi "github.com/signadot/cli/internal/locald/api/rootmanager"
 	sbmapi "github.com/signadot/cli/internal/locald/api/sandboxmanager"
+	sbmgr "github.com/signadot/cli/internal/locald/sandboxmanager"
 	"github.com/signadot/cli/internal/utils/system"
+	"github.com/signadot/go-sdk/client/sandboxes"
 	"github.com/signadot/libconnect/common/processes"
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc"
@@ -27,6 +30,7 @@ func newDisconnect(localConfig *config.Local) *cobra.Command {
 			return runDisconnect(cfg, args)
 		},
 	}
+	cfg.AddFlags(cmd)
 
 	return cmd
 }
@@ -46,7 +50,13 @@ func runDisconnect(cfg *config.LocalDisconnect, args []string) error {
 }
 
 func runDisconnectWith(cfg *config.LocalDisconnect, signadotDir string) error {
+	if cfg.CleanLocalSandboxes {
+		if err := cleanLocalSandboxes(cfg); err != nil {
+			return fmt.Errorf("couldn't clean-up local sandboxes, %w", err)
+		}
+	}
 
+	// perform the disconnect
 	runState := &runState{}
 	ticker := time.NewTicker(time.Second / 10)
 	defer ticker.Stop()
@@ -66,6 +76,37 @@ func runDisconnectWith(cfg *config.LocalDisconnect, signadotDir string) error {
 		return nil
 	}
 	return fmt.Errorf("signadot was not connected")
+}
+
+func cleanLocalSandboxes(cfg *config.LocalDisconnect) error {
+	// get status from sandboxmanager
+	status, err := sbmgr.GetStatus()
+	if err != nil {
+		if errors.Is(err, sbmgr.ErrSandboxManagerUnavailable) {
+			// local is already disconnected (or at least sandboxmanager is not
+			// running) there's nothing we can do here, just return
+			return nil
+		}
+		return err
+	}
+
+	// init SaaS API
+	if err := cfg.InitAPIConfig(); err != nil {
+		return err
+	}
+	for _, sb := range status.Sandboxes {
+		// delete the sandbox.
+		params := sandboxes.NewDeleteSandboxParams().
+			WithOrgName(cfg.Org).
+			WithSandboxName(sb.Name)
+		_, err := cfg.Client.Sandboxes.DeleteSandbox(params, nil)
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("Deleted sandbox %q.\n", sb.Name)
+	}
+	return nil
 }
 
 // we have a sandbox manager and a root manager to stop, and may be

--- a/internal/command/local/printers.go
+++ b/internal/command/local/printers.go
@@ -341,14 +341,14 @@ func (p *statusPrinter) printRuntimeConfig() {
 }
 
 func (p *statusPrinter) printErrors(errs []error) {
-	p.printLine(p.out, 0, fmt.Sprintf("Local connection not healthy!"), p.red("✗"))
+	p.printLine(p.out, 0, "Local connection not healthy!", p.red("✗"))
 	for _, err := range errs {
 		p.printLine(p.out, 0, err.Error(), "*")
 	}
 }
 
 func (p *statusPrinter) printSuccess() {
-	p.printLine(p.out, 0, fmt.Sprintf("Local connection healthy!"), p.green("✓"))
+	p.printLine(p.out, 0, "Local connection healthy!", p.green("✓"))
 	if p.status.OperatorInfo != nil {
 		p.printOperatorInfo()
 	}
@@ -430,9 +430,9 @@ func (p *statusPrinter) printSandboxStatus() {
 						portMap.BaselinePort, portMap.LocalAddress), "-")
 				}
 				if localwl.TunnelHealth.Healthy {
-					p.printLine(p.out, 2, fmt.Sprintf("connection ready"), p.green("✓"))
+					p.printLine(p.out, 2, "connection ready", p.green("✓"))
 				} else {
-					p.printLine(p.out, 2, fmt.Sprintf("connection not ready"), p.red("✗"))
+					p.printLine(p.out, 2, "connection not ready", p.red("✗"))
 				}
 			}
 		}

--- a/internal/config/local.go
+++ b/internal/config/local.go
@@ -96,6 +96,13 @@ func (c *LocalConnect) AddFlags(cmd *cobra.Command) {
 
 type LocalDisconnect struct {
 	*Local
+
+	// Flags
+	CleanLocalSandboxes bool
+}
+
+func (c *LocalDisconnect) AddFlags(cmd *cobra.Command) {
+	cmd.Flags().BoolVar(&c.CleanLocalSandboxes, "clean-local-sandboxes", false, "clean active local sandboxes")
 }
 
 type LocalStatus struct {

--- a/internal/locald/sandboxmanager/sdk.go
+++ b/internal/locald/sandboxmanager/sdk.go
@@ -2,6 +2,7 @@ package sandboxmanager
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/signadot/cli/internal/config"
@@ -12,6 +13,11 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
+)
+
+var (
+	ErrSandboxManagerUnavailable = errors.New(
+		"sandboxmanager is not running, start it with \"signadot local connect\"")
 )
 
 func GetStatus() (*sbmapi.StatusResponse, error) {
@@ -153,7 +159,7 @@ func processGRPCError(action string, err error) error {
 	if ok {
 		switch grpcStatus.Code() {
 		case codes.Unavailable:
-			return fmt.Errorf("sandboxmanager is not running, start it with \"signadot local connect\"")
+			return ErrSandboxManagerUnavailable
 		}
 	}
 	return fmt.Errorf("%s: %w", action, err)


### PR DESCRIPTION
Implementation of `signadot local disconnect --clean-local-sandboxes`