### PR TITLE
use panta machine-id for docker local

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/signadot/cli
 go 1.21
 
 require (
-	github.com/denisbrodbeck/machineid v1.0.1
 	github.com/docker/go-units v0.5.0
 	github.com/go-openapi/runtime v0.26.0
 	github.com/go-openapi/strfmt v0.21.7
@@ -11,6 +10,7 @@ require (
 	github.com/golang/protobuf v1.5.3
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/nsf/jsondiff v0.0.0-20210926074059-1e845ec5d249
+	github.com/panta/machineid v1.0.2
 	github.com/signadot/go-sdk v0.3.8-0.20231120112931-5aa0810b12b7
 	github.com/signadot/libconnect v0.1.1-0.20231117125146-85eb3e9106d5
 	github.com/spf13/cobra v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -78,8 +78,6 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/denisbrodbeck/machineid v1.0.1 h1:geKr9qtkB876mXguW2X6TU4ZynleN6ezuMSRhl4D7AQ=
-github.com/denisbrodbeck/machineid v1.0.1/go.mod h1:dJUwb7PTidGDeYyUBmXZ2GphQBbjJCrnectwCyxcUSI=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
@@ -342,6 +340,8 @@ github.com/onsi/gomega v1.23.0 h1:/oxKu9c2HVap+F3PfKort2Hw5DEU+HGlW8n+tguWsys=
 github.com/onsi/gomega v1.23.0/go.mod h1:Z/NWtiqwBrwUt4/2loMmHL63EDLnYHmVbuBpDr2vQAg=
 github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+1B0VhjKrZUs=
 github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
+github.com/panta/machineid v1.0.2 h1:LVYeEq1hZ+FwcM+/H6eB8KfXM2R5b2h1SWdnWwZ0OQw=
+github.com/panta/machineid v1.0.2/go.mod h1:AROj156fsca3R3rNw3q9h8xFkos25W9P0ZG9gu+3Uf0=
 github.com/pelletier/go-toml v1.7.0/go.mod h1:vwGMzjaWMwyfHwgIBhI2YUM4fB6nL6lVAvS1LBMMhTE=
 github.com/pelletier/go-toml v1.9.4 h1:tjENF6MfZAg8e4ZmZTeWaWiT2vXtsoO6+iuOjFhECwM=
 github.com/pelletier/go-toml v1.9.4/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=

--- a/internal/utils/system/system.go
+++ b/internal/utils/system/system.go
@@ -7,7 +7,7 @@ import (
 	"path"
 	"path/filepath"
 
-	"github.com/denisbrodbeck/machineid"
+	"github.com/panta/machineid"
 	"gopkg.in/natefinch/lumberjack.v2"
 )
 


### PR DESCRIPTION
Tested using connect to staging and 
```
docker build -t cli-local . -f Dockerfile.local
docker run -i -t --cap-add NET_ADMIN --entrypoint bash -v /Users/scott/.aws:/root/.aws -v /Users/scott/.signadot:/root/.signadot -v /Users/scott/.kube:/root/.kube  --rm cli-local
```

and Dockerfile.local:
```
23-11-24 scott@air cli % cat Dockerfile.local
#FROM signadot/signadot-cli as cli
FROM ubuntu as cli
COPY signadot /signadot

FROM amazon/aws-cli
COPY --from=cli /signadot /usr/bin/signadot
RUN yum install sudo -y
RUN yum install -y ca-certificates
RUN yum install iptables -y

# for testing
#RUN yum install vim

#RUN apt-get install -y curl
#RUN apt-get install wget
ENTRYPOINT ["/usr/bin/signadot"]
```
