### PR TITLE
Add a devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,39 @@
+ARG USER=signadot
+ARG GOARCH=amd64
+FROM ubuntu
+ARG USER
+ARG GOARCH
+
+RUN apt update
+RUN apt upgrade -y
+RUN apt-get install -y ca-certificates
+RUN apt-get install -y iptables
+RUN apt-get install -y sudo
+RUN apt-get install -y curl
+RUN apt-get install -y vim
+RUN apt-get install -y git
+RUN apt-get install -y python3
+RUN apt-get install -y python3.10-venv
+RUN apt-get install -y unzip
+RUN apt-get install -y wget
+
+COPY install-aws.sh /install-aws.sh
+RUN /install-aws.sh
+COPY install-go.sh /install-go.sh
+RUN GOARCH=$GOARCH /install-go.sh
+RUN /usr/local/go/bin/go install github.com/goreleaser/goreleaser@latest
+
+COPY signadot /usr/bin/signadot
+
+
+
+RUN adduser --disabled-password $USER
+RUN adduser $USER sudo
+RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+
+
+USER $USER
+WORKDIR /home/$USER
+
+ENTRYPOINT ["/bin/bash"]
+

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,20 @@
+{
+	"name": "signadot-aws",
+	"build": {
+		"dockerfile": "Dockerfile",
+		"args": {
+			"USER": "${localEnv:USER}",
+			"GOARCH": "${localEnv:GOARCH}"
+		}
+	},
+	"capAdd": ["NET_ADMIN"],
+	"remoteUser": "${localEnv:USER}",
+	"mounts": [
+		{"source": "${localEnv:HOME}/.signadot", "target": "/home/${localEnv:USER}/.signadot", "type": "bind"},
+		{"source": "${localEnv:HOME}/.kube", "target": "/home/${localEnv:USER}/.kube", "type": "bind"},
+		{"source": "${localEnv:HOME}/.aws", "target": "/home/${localEnv:USER}/.aws", "type": "bind"}
+	],
+	"features": {
+		"ghcr.io/brokeyourbike/devcontainer-features/staticcheck:0": {}
+	}
+}

--- a/.devcontainer/install-aws.sh
+++ b/.devcontainer/install-aws.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+#
+
+ln -s /usr/bin/python3 /usr/bin/python
+curl https://s3.amazonaws.com/aws-cli/awscli-bundle.zip -o awscli-bundle.zip
+unzip awscli-bundle.zip
+./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws
+

--- a/.devcontainer/install-go.sh
+++ b/.devcontainer/install-go.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+wget https://go.dev/dl/go1.21.5.linux-${GOARCH}.tar.gz
+rm -rf /usr/local/go 
+tar -C /usr/local -xzf go1.21.5.linux-${GOARCH}.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -15,3 +15,8 @@ build:
 
 release:
 	SIGNADOT_IMAGE_SUFFIX='' goreleaser release --rm-dist
+
+
+devcontainer:
+	go build -o .devcontainer/signadot ./cmd/signadot
+	GOARCH=$(go env GOARCH) devcontainer --workspace-folder . build


### PR DESCRIPTION
This adds a devcontainer, which can be useful as a reference for running the cli within docker and standardising build.

There is also a `make devcontainer` which builds and places the CLI binary and sets GOARCH.  This means the devcontainer build from VSCode won't work unless one runs `go build -o .devcontainer/signadot ./cmd/signadot` first.

This is somewhat a work in progress.  It only works w/ aws and signadot local type "PortForward",  I'd like to add
- support for google cloud
-  support for Minikube
I think it will work with type "ProxyAddress" 

and figure out how to make a devcontainer feature, so it is easy for folks to add signadot to a devcontainer.

But, it may be useful as is.  

Thoughts appreciated.

- 