### PR TITLE
Local wait default

### DIFF
--- a/internal/command/local/connect.go
+++ b/internal/command/local/connect.go
@@ -173,7 +173,7 @@ func runConnectImpl(out io.Writer, log *slog.Logger, localConfig *config.LocalCo
 	green := color.New(color.FgGreen).SprintFunc()
 	white := color.New(color.FgHiWhite, color.Bold).SprintFunc()
 	fmt.Fprintf(out, "\nsignadot local connect has been started %s\n", green("✓"))
-	if !localConfig.Wait {
+	if localConfig.NoWait {
 		fmt.Fprintf(out, "you can check its status with: %s\n", white("signadot local status"))
 		return nil
 	}

--- a/internal/config/local.go
+++ b/internal/config/local.go
@@ -1,8 +1,10 @@
 package config
 
 import (
+	"flag"
 	"fmt"
 	"os"
+	"strconv"
 	"time"
 
 	"github.com/signadot/libconnect/config"
@@ -89,10 +91,41 @@ func (c *LocalConnect) AddFlags(cmd *cobra.Command) {
 
 	cmd.Flags().BoolVar(&c.Unprivileged, "unprivileged", false, "run without root privileges")
 	cmd.Flags().BoolVar(&c.NoWait, "no-wait", false, "wait for connection healthy")
+	cmd.Flags().AddGoFlag(&flag.Flag{
+		Name: "wait",
+		Value: &waitFlagValue{
+			negPointer: &c.NoWait,
+		},
+		DefValue: "true",
+	})
 	cmd.Flags().DurationVar(&c.WaitTimeout, "wait-timeout", 10*time.Second, "timeout to wait")
 
 	cmd.Flags().BoolVar(&c.DumpCIConfig, "dump-ci-config", false, "dump connect invocation config")
 	cmd.Flags().MarkHidden("dump-ci-config")
+}
+
+type waitFlagValue struct {
+	negPointer *bool
+}
+
+func (w *waitFlagValue) Set(v string) error {
+	b, err := strconv.ParseBool(v)
+	if err != nil {
+		return err
+	}
+	*w.negPointer = !b
+	return nil
+}
+
+func (w *waitFlagValue) String() string {
+	if w == nil || w.negPointer == nil {
+		return "false"
+	}
+	return fmt.Sprintf("%t", *w.negPointer)
+}
+
+func (w *waitFlagValue) IsBoolFlag() bool {
+	return true
 }
 
 type LocalDisconnect struct {

--- a/internal/config/local.go
+++ b/internal/config/local.go
@@ -110,6 +110,7 @@ func (c *LocalConnect) AddFlags(cmd *cobra.Command) {
 
 	cmd.Flags().BoolVar(&c.DumpCIConfig, "dump-ci-config", false, "dump connect invocation config")
 	cmd.Flags().MarkHidden("dump-ci-config")
+	cmd.Flags().MarkHidden("wait")
 }
 
 type waitFlagValue struct {

--- a/internal/config/local.go
+++ b/internal/config/local.go
@@ -77,7 +77,7 @@ type LocalConnect struct {
 	// Flags
 	Cluster      string
 	Unprivileged bool
-	Wait         bool
+	NoWait       bool
 	WaitTimeout  time.Duration
 
 	// Hidden Flags
@@ -88,8 +88,9 @@ func (c *LocalConnect) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&c.Cluster, "cluster", "", "specify cluster connection config")
 
 	cmd.Flags().BoolVar(&c.Unprivileged, "unprivileged", false, "run without root privileges")
-	cmd.Flags().BoolVar(&c.Wait, "wait", false, "wait for connection healthy")
+	cmd.Flags().BoolVar(&c.NoWait, "no-wait", false, "wait for connection healthy")
 	cmd.Flags().DurationVar(&c.WaitTimeout, "wait-timeout", 10*time.Second, "timeout to wait")
+
 	cmd.Flags().BoolVar(&c.DumpCIConfig, "dump-ci-config", false, "dump connect invocation config")
 	cmd.Flags().MarkHidden("dump-ci-config")
 }

--- a/internal/config/local.go
+++ b/internal/config/local.go
@@ -90,7 +90,7 @@ func (c *LocalConnect) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&c.Cluster, "cluster", "", "specify cluster connection config")
 
 	cmd.Flags().BoolVar(&c.Unprivileged, "unprivileged", false, "run without root privileges")
-	cmd.Flags().BoolVar(&c.NoWait, "no-wait", false, "wait for connection healthy")
+	cmd.Flags().BoolVar(&c.NoWait, "no-wait", false, "don't wait for connection healthy")
 	cmd.Flags().AddGoFlag(&flag.Flag{
 		Name: "wait",
 		Value: &waitFlagValue{

--- a/internal/config/local.go
+++ b/internal/config/local.go
@@ -104,6 +104,7 @@ func (c *LocalConnect) AddFlags(cmd *cobra.Command) {
 			negPointer: &c.NoWait,
 		},
 		DefValue: "true",
+		Usage:    "wait for the connection to become healthy",
 	})
 	cmd.Flags().DurationVar(&c.WaitTimeout, "wait-timeout", 10*time.Second, "timeout to wait")
 


### PR DESCRIPTION
This PR makes `--wait` the default for `signadot local connect` and adds the flag `--no-wait`
