### PR TITLE
support no service local workloads

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/nsf/jsondiff v0.0.0-20210926074059-1e845ec5d249
 	github.com/panta/machineid v1.0.2
 	github.com/signadot/go-sdk v0.3.8-0.20231120112931-5aa0810b12b7
-	github.com/signadot/libconnect v0.1.1-0.20240219154241-dce58bd5adf0
+	github.com/signadot/libconnect v0.1.1-0.20240221130354-fe328b4c8dc3
 	github.com/spf13/cobra v1.6.0
 	github.com/spf13/viper v1.11.0
 	github.com/theckman/yacspin v0.13.12

--- a/go.sum
+++ b/go.sum
@@ -364,8 +364,8 @@ github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUz
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/signadot/go-sdk v0.3.8-0.20231120112931-5aa0810b12b7 h1:PgIayNxGde2TvVYCFOsDVZ65WsrBdlh6MN3tzHGeXtM=
 github.com/signadot/go-sdk v0.3.8-0.20231120112931-5aa0810b12b7/go.mod h1:mLzoMuSE0GsFLONRjjYYHQBsU9twXML1BrExSvpMqeI=
-github.com/signadot/libconnect v0.1.1-0.20240219154241-dce58bd5adf0 h1:rdv/D4W3FvKa85tGBh/nQG8+i+JCtcVXaGdV/2xN9fs=
-github.com/signadot/libconnect v0.1.1-0.20240219154241-dce58bd5adf0/go.mod h1:4OzWoyxyoh56h4jgCw/FBJVxyHB45qpwHDVWbsGfFTg=
+github.com/signadot/libconnect v0.1.1-0.20240221130354-fe328b4c8dc3 h1:MvDmXSMEgpICwpFbA4nMw8TbF8VRZwzjj3xK8AAZE4I=
+github.com/signadot/libconnect v0.1.1-0.20240221130354-fe328b4c8dc3/go.mod h1:Rgx68v/Bux8D2Z2jx0aB8Mwjb5WFkKmXrSErs0T+YXQ=
 github.com/sirupsen/logrus v1.4.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=

--- a/internal/locald/sandboxmanager/revtun.go
+++ b/internal/locald/sandboxmanager/revtun.go
@@ -30,9 +30,10 @@ func newRevtun(log *slog.Logger, rtc revtun.Client, rk string,
 	xw *tunapiv1.ExternalWorkload) (*rt, error) {
 	// define the revtun config (that will be used to setup the reverse tunnel)
 	rtConfig := &rtproto.Config{
-		SandboxRoutingKey: rk,
-		ExternalWorkload:  xw.Name,
-		Forwards:          []rtproto.Forward{},
+		SandboxRoutingKey:         rk,
+		ExternalWorkload:          xw.Name,
+		ExternalWorkloadNamespace: xw.Baseline.Namespace,
+		Forwards:                  []rtproto.Forward{},
 	}
 	for _, pm := range xw.WorkloadPortMapping {
 		kind, err := kindToRemoteURLTLD(xw.Baseline.Kind)


### PR DESCRIPTION
This depends on https://github.com/signadot/libconnect/pull/53

To have the actual new support, this also depends on and https://github.com/signadot/signadot/pull/4178 and
https://github.com/signadot/signadot/pull/4176

However, this should be harmless and simply continue to fail for no service local workloads on old operators or before the apiserver check change has merged.
