### PR TITLE
Proxy implementation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,9 +10,10 @@ require (
 	github.com/golang/protobuf v1.5.3
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/nsf/jsondiff v0.0.0-20210926074059-1e845ec5d249
+	github.com/oklog/run v1.1.0
 	github.com/panta/machineid v1.0.2
 	github.com/signadot/go-sdk v0.3.8-0.20231120112931-5aa0810b12b7
-	github.com/signadot/libconnect v0.1.1-0.20240219154241-dce58bd5adf0
+	github.com/signadot/libconnect v0.1.1-0.20240222123916-2b3a98e43cf7
 	github.com/spf13/cobra v1.6.0
 	github.com/spf13/viper v1.11.0
 	github.com/theckman/yacspin v0.13.12
@@ -33,7 +34,9 @@ require (
 	github.com/Azure/go-autorest/autorest/date v0.3.0 // indirect
 	github.com/Azure/go-autorest/logger v0.2.1 // indirect
 	github.com/Azure/go-autorest/tracing v0.6.0 // indirect
+	github.com/efarrer/iothrottler v0.0.3 // indirect
 	github.com/golang-jwt/jwt/v4 v4.2.0 // indirect
+	github.com/mwitkow/grpc-proxy v0.0.0-20230212185441-f345521cb9c9 // indirect
 	k8s.io/kubectl v0.25.12 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -81,6 +81,8 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
+github.com/efarrer/iothrottler v0.0.3 h1:6m8eKBQ1ouigjXQoBxwEWz12fUGGYfYppEJVcyZFcYg=
+github.com/efarrer/iothrottler v0.0.3/go.mod h1:zGWF5N0NKSCskcPFytDAFwI121DdU/NfW4XOjpTR+ys=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153 h1:yUdfgN0XgIJw7foRItutHYUIhlcKzcSf5vDpdhQAKTc=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/emicklei/go-restful/v3 v3.9.0 h1:XwGDlfxEnQZzuopoqxwSEllNcCOM9DhhFyhFIIGKwxE=
@@ -211,6 +213,7 @@ github.com/golang/protobuf v1.4.1/go.mod h1:U8fpvMrcmy5pZrNK1lt4xCsGvpyWQ/VVv6QD
 github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/golang/protobuf v1.4.3/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
+github.com/golang/protobuf v1.5.1/go.mod h1:DopwsBzvsk0Fs44TXzsVbJyPhcCPeIwnvohx4u74HPM=
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/golang/protobuf v1.5.3 h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg=
 github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
@@ -329,9 +332,13 @@ github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjY
 github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
+github.com/mwitkow/grpc-proxy v0.0.0-20230212185441-f345521cb9c9 h1:62uLwA3l2JMH84liO4ZhnjTH5PjFyCYxbHLgXPaJMtI=
+github.com/mwitkow/grpc-proxy v0.0.0-20230212185441-f345521cb9c9/go.mod h1:MvMXoufZAtqExNexqi4cjrNYE9MefKddKylxjS+//n0=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nsf/jsondiff v0.0.0-20210926074059-1e845ec5d249 h1:NHrXEjTNQY7P0Zfx1aMrNhpgxHmow66XQtm0aQLY0AE=
 github.com/nsf/jsondiff v0.0.0-20210926074059-1e845ec5d249/go.mod h1:mpRZBD8SJ55OIICQ3iWH0Yz3cjzA61JdqMLoWXeB2+8=
+github.com/oklog/run v1.1.0 h1:GEenZ1cK0+q0+wsJew9qUg/DyD8k3JzYsZAi5gYi2mA=
+github.com/oklog/run v1.1.0/go.mod h1:sVPdnTZT1zYwAJeCMu2Th4T21pA3FPOQRfWjQlk7DVU=
 github.com/oklog/ulid v1.3.1 h1:EGfNDEx6MqHz8B3uNV6QAib1UR2Lm97sHi3ocA6ESJ4=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/onsi/ginkgo/v2 v2.4.0 h1:+Ig9nvqgS5OBSACXNk15PLdp0U9XPYROt9CFzVdFGIs=
@@ -364,8 +371,8 @@ github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUz
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/signadot/go-sdk v0.3.8-0.20231120112931-5aa0810b12b7 h1:PgIayNxGde2TvVYCFOsDVZ65WsrBdlh6MN3tzHGeXtM=
 github.com/signadot/go-sdk v0.3.8-0.20231120112931-5aa0810b12b7/go.mod h1:mLzoMuSE0GsFLONRjjYYHQBsU9twXML1BrExSvpMqeI=
-github.com/signadot/libconnect v0.1.1-0.20240219154241-dce58bd5adf0 h1:rdv/D4W3FvKa85tGBh/nQG8+i+JCtcVXaGdV/2xN9fs=
-github.com/signadot/libconnect v0.1.1-0.20240219154241-dce58bd5adf0/go.mod h1:4OzWoyxyoh56h4jgCw/FBJVxyHB45qpwHDVWbsGfFTg=
+github.com/signadot/libconnect v0.1.1-0.20240222123916-2b3a98e43cf7 h1:uxbOsEDGOufnwONqMIjk95BeoLeHCfuCPenFtQT9ir8=
+github.com/signadot/libconnect v0.1.1-0.20240222123916-2b3a98e43cf7/go.mod h1:Tuwall0ce/N/sPtGQNdaZGrxlzTHOJUWm6FqNxlxOsM=
 github.com/sirupsen/logrus v1.4.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
@@ -517,6 +524,8 @@ golang.org/x/net v0.0.0-20201031054903-ff519b6c9102/go.mod h1:sp8m0HH+o8qH0wwXwY
 golang.org/x/net v0.0.0-20201209123823-ac852fbbde11/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20201224014010-6772e930b67b/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
+golang.org/x/net v0.0.0-20210316092652-d523dce5a7f4/go.mod h1:RBQZq4jEuRlivfhVLdyRGr576XBO4/greRjx4P4O3yc=
+golang.org/x/net v0.0.0-20210331212208-0fccb6fa2b5c/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/net v0.0.0-20210421230115-4e50805a0758/go.mod h1:72T/g9IO56b78aLF+1Kcs5dz7/ng1VjMUvfKvpfy+jM=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
@@ -545,6 +554,7 @@ golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4 h1:uVc8UZUe6tr40fFVnUP5Oj+veunVezqYl9z7DYw9xzw=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -584,6 +594,10 @@ golang.org/x/sys v0.0.0-20201201145000-ef89a241ccb3/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210104204734-6f8348627aad/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210225134936-a50acf3fe073/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210315160823-c6e025ad8005/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210331175145-43e1dd70ce54/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210420072515-93ed5bcd2bfe/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423185535-09eb48e85fd7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -741,6 +755,7 @@ google.golang.org/genproto v0.0.0-20201210142538-e3217bee35cc/go.mod h1:FWY/as6D
 google.golang.org/genproto v0.0.0-20201214200347-8c77b98c765d/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20210108203827-ffc7fda8c3d7/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20210226172003-ab064af71705/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
+google.golang.org/genproto v0.0.0-20210401141331-865547bb08e2/go.mod h1:9lPAdzaEmUacj36I+k7YKbEc5CXzPIeORRgDAUOu28A=
 google.golang.org/genproto v0.0.0-20230410155749-daa745c078e1 h1:KpwkzHKEF7B9Zxg18WzOa7djJ+Ha5DzthMyZYQfEn2A=
 google.golang.org/genproto v0.0.0-20230410155749-daa745c078e1/go.mod h1:nKE/iIaLqn2bQwXBg8f1g2Ylh6r5MN5CmZvuzZCgsCU=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
@@ -759,6 +774,7 @@ google.golang.org/grpc v1.31.1/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM
 google.golang.org/grpc v1.33.2/go.mod h1:JMHMWHQWaTccqQQlmk3MJZS+GWXOdAesneDmEnv2fbc=
 google.golang.org/grpc v1.34.0/go.mod h1:WotjhfgOW/POjDeRt8vscBtXq+2VjORFy659qA51WJ8=
 google.golang.org/grpc v1.35.0/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
+google.golang.org/grpc v1.36.1/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
 google.golang.org/grpc v1.56.0 h1:+y7Bs8rtMd07LeXmL3NxcTLn7mUkbKZqEpPhMNkwJEE=
 google.golang.org/grpc v1.56.0/go.mod h1:I9bI3vqKfayGqPUAwGdOSu7kt6oIJLixfffKrpXqQ9s=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
@@ -805,6 +821,7 @@ honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
+honnef.co/go/tools v0.1.3/go.mod h1:NgwopIslSNH47DimFoV78dnkksY2EFtX0ajyb3K/las=
 k8s.io/api v0.26.3 h1:emf74GIQMTik01Aum9dPP0gAypL8JTLl/lHa4V9RFSU=
 k8s.io/api v0.26.3/go.mod h1:PXsqwPMXBSBcL1lJ9CYDKy7kIReUydukS5JiRlxC3qE=
 k8s.io/apimachinery v0.26.3 h1:dQx6PNETJ7nODU3XPtrwkfuubs6w7sX0M8n61zHIV/k=

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -8,6 +8,7 @@ import (
 	"github.com/signadot/cli/internal/command/cluster"
 	"github.com/signadot/cli/internal/command/local"
 	"github.com/signadot/cli/internal/command/locald"
+	"github.com/signadot/cli/internal/command/proxy"
 	"github.com/signadot/cli/internal/command/resourceplugin"
 	"github.com/signadot/cli/internal/command/routegroup"
 	"github.com/signadot/cli/internal/command/sandbox"
@@ -38,6 +39,7 @@ func New() *cobra.Command {
 		resourceplugin.New(cfg),
 		local.New(cfg),
 		locald.New(cfg),
+		proxy.New(cfg),
 		bug.New(cfg),
 	)
 

--- a/internal/command/local/connect.go
+++ b/internal/command/local/connect.go
@@ -27,7 +27,7 @@ func newConnect(localConfig *config.Local) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "connect",
-		Short: "connect local machine to cluster",
+		Short: "Connect local machine to cluster",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runConnect(cmd, cmd.OutOrStdout(), cfg, args)
 		},

--- a/internal/command/local/disconnect.go
+++ b/internal/command/local/disconnect.go
@@ -25,7 +25,7 @@ func newDisconnect(localConfig *config.Local) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "disconnect",
-		Short: "disconnect local machine from cluster",
+		Short: "Disconnect local machine from cluster",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runDisconnect(cfg, args)
 		},

--- a/internal/command/local/status.go
+++ b/internal/command/local/status.go
@@ -18,7 +18,7 @@ func newStatus(localConfig *config.Local) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "status",
-		Short: "show status of the local machine's connection with cluster",
+		Short: "Show status of the local machine's connection with cluster",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runStatus(cfg, cmd.OutOrStdout(), args)
 		},

--- a/internal/command/proxy/connect.go
+++ b/internal/command/proxy/connect.go
@@ -1,0 +1,105 @@
+package proxy
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+
+	"github.com/oklog/run"
+	"github.com/signadot/cli/internal/config"
+	routegroups "github.com/signadot/go-sdk/client/route_groups"
+	"github.com/signadot/go-sdk/client/sandboxes"
+	"github.com/spf13/cobra"
+)
+
+func newConnect(proxyConfig *config.Proxy) *cobra.Command {
+	cfg := &config.ProxyConnect{
+		Proxy: proxyConfig,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "connect [--sandbox SANDBOX|--routegroup ROUTEGROUP|--cluster CLUSTER] --map <target-protocol>://<target-addr>|<bind-addr> [--map <target-protocol>://<target-addr>|<bind-addr>]",
+		Short: "Proxy connections to the specified mappings",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runConnect(cmd, cmd.OutOrStdout(), cfg, args)
+		},
+	}
+	cfg.AddFlags(cmd)
+
+	return cmd
+}
+
+func runConnect(cmd *cobra.Command, out io.Writer, cfg *config.ProxyConnect, args []string) error {
+	if err := cfg.InitProxyConfig(); err != nil {
+		return err
+	}
+	if err := cfg.Validate(); err != nil {
+		return err
+	}
+
+	// define the cluster and routing key to use
+	var cluster, routingKey string
+
+	if cfg.Sandbox != "" {
+		// resolve the sandbox
+		params := sandboxes.NewGetSandboxParams().
+			WithOrgName(cfg.Org).WithSandboxName(cfg.Sandbox)
+		resp, err := cfg.Client.Sandboxes.GetSandbox(params, nil)
+		if err != nil {
+			return err
+		}
+
+		cluster = *resp.Payload.Spec.Cluster
+		routingKey = resp.Payload.RoutingKey
+	} else if cfg.RouteGroup != "" {
+		// resolve the routegroup
+		params := routegroups.NewGetRoutegroupParams().
+			WithOrgName(cfg.Org).WithRoutegroupName(cfg.RouteGroup)
+		resp, err := cfg.Client.RouteGroups.GetRoutegroup(params, nil)
+		if err != nil {
+			return err
+		}
+
+		cluster = resp.Payload.Spec.Cluster
+		routingKey = resp.Payload.RoutingKey
+	} else {
+		cluster = cfg.Cluster
+	}
+
+	logLevel := slog.LevelInfo
+	if cfg.Debug {
+		logLevel = slog.LevelDebug
+	}
+	log := slog.New(slog.NewTextHandler(out, &slog.HandlerOptions{
+		Level: logLevel,
+	}))
+
+	var servers run.Group
+	for i := range cfg.ProxyMappings {
+		pm := &cfg.ProxyMappings[i]
+
+		proxyServer, err := NewProxyServer(&proxyConfig{
+			log:        log,
+			cfg:        cfg.Proxy,
+			routingKey: routingKey,
+			cluster:    cluster,
+			mapping:    pm,
+		})
+		if err != nil {
+			return err
+		}
+		servers.Add(
+			proxyServer.Start,
+			func(error) { proxyServer.Shutdown(context.Background()) },
+		)
+	}
+
+	switch err := servers.Run().(type) {
+	case run.SignalError:
+		log.Info(fmt.Sprintf("Received %v signal. Shutdown complete.", err.Signal.String()))
+		return nil
+	default:
+		return err
+	}
+}

--- a/internal/command/proxy/proxy.go
+++ b/internal/command/proxy/proxy.go
@@ -1,4 +1,4 @@
-package local
+package proxy
 
 import (
 	"github.com/signadot/cli/internal/config"
@@ -6,18 +6,16 @@ import (
 )
 
 func New(api *config.API) *cobra.Command {
-	cfg := &config.Local{API: api}
+	cfg := &config.Proxy{API: api}
 
 	cmd := &cobra.Command{
-		Use:   "local",
-		Short: "Connect local machine with cluster",
+		Use:   "proxy",
+		Short: "Forward proxy to cluster services",
 	}
 
 	// Subcommands
 	cmd.AddCommand(
 		newConnect(cfg),
-		newStatus(cfg),
-		newDisconnect(cfg),
 	)
 
 	return cmd

--- a/internal/command/proxy/server.go
+++ b/internal/command/proxy/server.go
@@ -1,0 +1,131 @@
+package proxy
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+
+	"github.com/signadot/cli/internal/config"
+	"github.com/signadot/libconnect/proxy/grpcproxy"
+	"github.com/signadot/libconnect/proxy/httpconnect"
+	"github.com/signadot/libconnect/proxy/httpproxy"
+	"github.com/signadot/libconnect/proxy/tcpproxy"
+	"google.golang.org/grpc"
+)
+
+type proxyConfig struct {
+	log        *slog.Logger
+	cfg        *config.Proxy
+	routingKey string
+	cluster    string
+	mapping    *config.ProxyMapping
+}
+
+type proxyServer struct {
+	*proxyConfig
+
+	proxyHeaders http.Header
+	ln           net.Listener
+	tcpProxy     *tcpproxy.Proxy
+	httpServer   *http.Server
+	grpcServer   *grpc.Server
+}
+
+func NewProxyServer(conf *proxyConfig) (*proxyServer, error) {
+	// create a listener
+	ln, err := net.Listen("tcp", conf.mapping.BindAddr)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't listen at %s, %w", conf.mapping.BindAddr, err)
+	}
+
+	// setup needed header to send to the proxy
+	proxyHeaders := http.Header{}
+	proxyHeaders.Add(config.APIKeyHeader, conf.cfg.GetAPIKey())
+	proxyHeaders.Add(config.ClusterHeader, conf.cluster)
+
+	return &proxyServer{
+		proxyConfig:  conf,
+		ln:           ln,
+		proxyHeaders: proxyHeaders,
+	}, nil
+}
+
+func (p *proxyServer) Start() error {
+	switch p.mapping.TargetProto {
+	case "tcp":
+		return p.runTCPServer()
+	case "http":
+		return p.runHTTPProxy()
+	case "https":
+		return p.runHTTPProxy()
+	case "grpc":
+		p.runGRPCProxy()
+	}
+	return nil
+}
+
+func (p *proxyServer) Shutdown(ctx context.Context) {
+	if p.ln != nil {
+		p.ln.Close()
+	}
+	if p.tcpProxy != nil {
+		p.tcpProxy.Close()
+	}
+	if p.httpServer != nil {
+		p.httpServer.Shutdown(ctx)
+	}
+	if p.grpcServer != nil {
+		p.grpcServer.GracefulStop()
+	}
+}
+
+func (p *proxyServer) runHTTPProxy() error {
+	proxy, err := httpproxy.NewProxy(p.log, p.cfg.ProxyURL, p.proxyHeaders, p.mapping.GetTarget(), p.routingKey)
+	if err != nil {
+		return err
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", proxy.ProxyRequestHandler())
+	p.httpServer = &http.Server{
+		Handler: mux,
+	}
+
+	p.log.Info("starting http proxy", "targetURL", p.mapping.GetTarget(), "bindAddr", p.mapping.BindAddr)
+	return p.httpServer.Serve(p.ln)
+}
+
+func (p *proxyServer) runGRPCProxy() error {
+	proxy, err := grpcproxy.NewProxy(p.log, p.cfg.ProxyURL, p.proxyHeaders, p.mapping.GetTarget(), p.routingKey)
+	if err != nil {
+		return err
+	}
+
+	p.grpcServer = grpc.NewServer(
+		grpc.UnknownServiceHandler(proxy.StreamHandler()),
+	)
+
+	p.log.Info("starting grpc proxy", "targetURL", p.mapping.GetTarget(), "bindAddr", p.mapping.BindAddr)
+	return p.grpcServer.Serve(p.ln)
+}
+
+func (p *proxyServer) runTCPServer() error {
+	dialer := httpconnect.NewDialer(p.log, p.cfg.ProxyURL, p.proxyHeaders)
+
+	var err error
+	p.tcpProxy, err = tcpproxy.NewProxy(&tcpproxy.Config{
+		Log: p.log,
+		Dialer: func(resolvData any) (net.Conn, error) {
+			conn, err := dialer.DialContext(context.Background(), "tcp", p.mapping.TargetAddr)
+			return conn, err
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	p.log.Info("starting tcp proxy", "targetURL", p.mapping.GetTarget(), "bindAddr", p.mapping.BindAddr)
+	return p.tcpProxy.Serve(p.ln)
+}

--- a/internal/config/api.go
+++ b/internal/config/api.go
@@ -91,7 +91,7 @@ func (a *API) InitAPITransport(apiKey string) error {
 
 	// Add auth info to every request.
 	transport := oaclient.New(tc.Host, tc.BasePath, tc.Schemes)
-	transport.DefaultAuthentication = oaclient.APIKeyAuth("signadot-api-key", "header", apiKey)
+	transport.DefaultAuthentication = oaclient.APIKeyAuth(APIKeyHeader, "header", apiKey)
 	transport.SetDebug(a.Debug)
 
 	// Add User-Agent to every request

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -1,0 +1,6 @@
+package config
+
+const (
+	APIKeyHeader  = "signadot-api-key"
+	ClusterHeader = "signadot-cluster"
+)

--- a/internal/config/proxy.go
+++ b/internal/config/proxy.go
@@ -1,0 +1,148 @@
+package config
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"net/url"
+	"regexp"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+type Proxy struct {
+	*API
+
+	ProxyURL string
+}
+
+func (p *Proxy) InitProxyConfig() error {
+	if err := p.API.InitAPIConfig(); err != nil {
+		return err
+	}
+
+	// Allow Proxy URL to be overridden (e.g. for talking to dev/staging).
+	if proxyURL := viper.GetString("proxy_url"); proxyURL != "" {
+		_, err := url.Parse(proxyURL)
+		if err != nil {
+			return fmt.Errorf("invalid proxy_url: %w", err)
+		}
+		p.ProxyURL = proxyURL
+
+	} else {
+		p.ProxyURL = "https://proxy.signadot.com"
+	}
+	return nil
+}
+
+func (p *Proxy) GetAPIKey() string {
+	return viper.GetString("api_key")
+}
+
+type ProxyConnect struct {
+	*Proxy
+
+	// Flags
+	Sandbox       string
+	RouteGroup    string
+	Cluster       string
+	ProxyMappings ProxyMappings
+}
+
+func (pc *ProxyConnect) Validate() error {
+	c := 0
+	if pc.Sandbox != "" {
+		c += 1
+	}
+	if pc.RouteGroup != "" {
+		c += 1
+	}
+	if pc.Cluster != "" {
+		c += 1
+	}
+
+	if c == 0 {
+		return errors.New("you should specify one of '--sandbox', '--routegroup' or '--cluster'")
+	}
+	if c > 1 {
+		return errors.New("only one of '--sandbox', '--routegroup' or '--cluster' should be specified")
+	}
+
+	for i := range pc.ProxyMappings {
+		pm := &pc.ProxyMappings[i]
+		if err := pm.Validate(); err != nil {
+			return err
+		}
+
+	}
+	return nil
+}
+
+type ProxyMapping struct {
+	TargetProto string
+	TargetAddr  string
+	BindAddr    string
+}
+
+func (pm *ProxyMapping) Validate() error {
+	switch pm.TargetProto {
+	case "tcp":
+	case "http":
+	case "https":
+	case "grpc":
+	default:
+		return fmt.Errorf("unsupported '%s' protocol, only 'tcp', 'http', 'https' and 'grpc' are supported", pm.TargetProto)
+	}
+	return nil
+}
+
+func (pm *ProxyMapping) GetTarget() string {
+	return fmt.Sprintf("%s://%s", pm.TargetProto, pm.TargetAddr)
+}
+
+func (pm *ProxyMapping) String() string {
+	return fmt.Sprintf("%s://%s|%s", pm.TargetProto, pm.TargetAddr, pm.BindAddr)
+}
+
+type ProxyMappings []ProxyMapping
+
+func (pms *ProxyMappings) String() string {
+	b := bytes.NewBuffer(nil)
+	for i := range *pms {
+		pm := &(*pms)[i]
+		if i != 0 {
+			fmt.Fprintf(b, " ")
+		}
+		fmt.Fprintf(b, "--map %s", pm)
+	}
+	return b.String()
+}
+
+// Set appends a new argument  to instance of Nargs
+func (pms *ProxyMappings) Set(arg string) error {
+	regex := regexp.MustCompile(`^(.+?)://(.+?)\|(.+)$`)
+	matches := regex.FindStringSubmatch(arg)
+	if matches == nil || len(matches) != 4 {
+		return fmt.Errorf("invalid format, expected \"<target-protocol>://<target-addr>|<bind-addr>\"")
+	}
+
+	*pms = append(*pms, ProxyMapping{
+		TargetProto: matches[1],
+		TargetAddr:  matches[2],
+		BindAddr:    matches[3],
+	})
+	return nil
+}
+
+// Type is a no-op
+func (pms *ProxyMappings) Type() string {
+	return "string"
+}
+
+func (c *ProxyConnect) AddFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(&c.Sandbox, "sandbox", "s", "", "run the proxy in the context of the specificed sandbox")
+	cmd.Flags().StringVarP(&c.RouteGroup, "routegroup", "r", "", "run the proxy in the context of the specificed routegroup")
+	cmd.Flags().StringVarP(&c.Cluster, "cluster", "c", "", "target cluster")
+	cmd.Flags().VarP(&c.ProxyMappings, "map", "m", "--map <target-protocol>://<target-addr>|<bind-addr>")
+}

--- a/internal/config/proxy.go
+++ b/internal/config/proxy.go
@@ -47,7 +47,7 @@ type ProxyConnect struct {
 	Sandbox       string
 	RouteGroup    string
 	Cluster       string
-	ProxyMappings ProxyMappings
+	ProxyMappings []ProxyMapping
 }
 
 func (pc *ProxyConnect) Validate() error {
@@ -105,9 +105,9 @@ func (pm *ProxyMapping) String() string {
 	return fmt.Sprintf("%s://%s|%s", pm.TargetProto, pm.TargetAddr, pm.BindAddr)
 }
 
-type ProxyMappings []ProxyMapping
+type proxyMappings []ProxyMapping
 
-func (pms *ProxyMappings) String() string {
+func (pms *proxyMappings) String() string {
 	b := bytes.NewBuffer(nil)
 	for i := range *pms {
 		pm := &(*pms)[i]
@@ -120,7 +120,7 @@ func (pms *ProxyMappings) String() string {
 }
 
 // Set appends a new argument  to instance of Nargs
-func (pms *ProxyMappings) Set(arg string) error {
+func (pms *proxyMappings) Set(arg string) error {
 	regex := regexp.MustCompile(`^(.+?)://(.+?)\|(.+)$`)
 	matches := regex.FindStringSubmatch(arg)
 	if matches == nil || len(matches) != 4 {
@@ -136,7 +136,7 @@ func (pms *ProxyMappings) Set(arg string) error {
 }
 
 // Type is a no-op
-func (pms *ProxyMappings) Type() string {
+func (pms *proxyMappings) Type() string {
 	return "string"
 }
 
@@ -144,5 +144,5 @@ func (c *ProxyConnect) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&c.Sandbox, "sandbox", "s", "", "run the proxy in the context of the specificed sandbox")
 	cmd.Flags().StringVarP(&c.RouteGroup, "routegroup", "r", "", "run the proxy in the context of the specificed routegroup")
 	cmd.Flags().StringVarP(&c.Cluster, "cluster", "c", "", "target cluster")
-	cmd.Flags().VarP(&c.ProxyMappings, "map", "m", "--map <target-protocol>://<target-addr>|<bind-addr>")
+	cmd.Flags().VarP((*proxyMappings)(&c.ProxyMappings), "map", "m", "--map <target-protocol>://<target-addr>|<bind-addr>")
 }


### PR DESCRIPTION
Implementation of `signadot proxy connect`:

```bash
$ signadot proxy connect --help
Proxy connections to the specified mappings

Usage:
  signadot proxy connect [--sandbox SANDBOX|--routegroup ROUTEGROUP|--cluster CLUSTER] --map <target-protocol>://<target-addr>|<bind-addr> [--map <target-protocol>://<target-addr>|<bind-addr>] [flags]

Flags:
  -c, --cluster string      target cluster
  -h, --help                help for connect
  -m, --map string          --map <target-protocol>://<target-addr>|<bind-addr>
  -r, --routegroup string   run the proxy in the context of the specificed routegroup
  -s, --sandbox string      run the proxy in the context of the specificed sandbox

Global Flags:
      --config string   config file (default is $HOME/.signadot/config.yaml)
      --debug           enable debug output
  -o, --output string   output format (json|yaml)
```

This PR depends on: https://github.com/signadot/libconnect/pull/54 and https://github.com/signadot/signadot/pull/4181.
Here are some examples:

``` bash
$ signadot proxy connect  --cluster test \
   --map "http://location.hotrod-devmesh:8081|localhost:3332" \
   --map "grpc://route.hotrod-devmesh:8083|localhost:3333" \
   --map "tcp://mysql.hotrod-devmesh:3306|localhost:3334"


# Access location service:
$ curl localhost:3332/locations
[{"ID":1,"Name":"My Home","Coordinates":"231,773"},{"ID":123,"Name":"Rachel's Floral Designs","Coordinates":"115,277"},{"ID":392,"Name":"Trom Chocolatier","Coordinates":"577,322"},{"ID":567,"Name":"Amazing Coffee Roasters","Coordinates":"211,653"},{"ID":731,"Name":"Japanese Desserts","Coordinates":"728,326"}]


# Access route service:
$ docker run --network=host fullstorydev/grpcurl -plaintext -d '{"from": "231,773", "to": "115,277"}' localhost:3333 route.RoutesService/FindRoute
{
  "etaSeconds": 258
}


# Access mysql DB:
$ mysql -P 3334 -pabc -Dlocation
mysql: [Warning] Using a password on the command line interface can be insecure.
Reading table information for completion of table and column names
You can turn off this feature to get a quicker startup with -A

Welcome to the MySQL monitor.  Commands end with ; or \g.
Your MySQL connection id is 13
Server version: 11.2.2-MariaDB-1:11.2.2+maria~ubu2204 mariadb.org binary distribution

Copyright (c) 2000, 2024, Oracle and/or its affiliates.

Oracle is a registered trademark of Oracle Corporation and/or its
affiliates. Other names may be trademarks of their respective
owners.

Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.

mysql>
``` 