### PR TITLE
Validate cluster parameter in local proxy

### DIFF
--- a/internal/command/local/proxy.go
+++ b/internal/command/local/proxy.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/oklog/run"
 	"github.com/signadot/cli/internal/config"
+	clusters "github.com/signadot/go-sdk/client/cluster"
 	routegroups "github.com/signadot/go-sdk/client/route_groups"
 	"github.com/signadot/go-sdk/client/sandboxes"
 	"github.com/signadot/libconnect/common/controlplaneproxy"
@@ -67,6 +68,12 @@ func runProxy(cmd *cobra.Command, out io.Writer, cfg *config.LocalProxy, args []
 		cluster = resp.Payload.Spec.Cluster
 		routingKey = resp.Payload.RoutingKey
 	} else {
+		// validate the cluster
+		params := clusters.NewGetClusterParams().
+			WithOrgName(cfg.Org).WithClusterName(cfg.Cluster)
+		if _, err := cfg.Client.Cluster.GetCluster(params, nil); err != nil {
+			return err
+		}
 		cluster = cfg.Cluster
 	}
 


### PR DESCRIPTION
Before:

```bash
$ signadot local proxy --cluster signadot-staging    --map "http://location.hotrod-devmesh:8081|localhost:3332"    --map "grpc://route.hotrod-devmesh:8083|localhost:3333"    --map "tcp://mysql.hotrod-devmesh:3306|localhost:3334"
time=2024-02-29T16:03:07.469-03:00 level=INFO msg="starting TCP proxy" bindAddr=localhost:3334 targetURL=tcp://mysql.hotrod-devmesh:3306
time=2024-02-29T16:03:07.469-03:00 level=INFO msg="starting gRPC proxy" bindAddr=localhost:3333 targetURL=grpc://route.hotrod-devmesh:8083
time=2024-02-29T16:03:07.469-03:00 level=INFO msg="starting HTTP proxy" bindAddr=localhost:3332 targetURL=http://location.hotrod-devmesh:8081
time=2024-02-29T16:03:07.471-03:00 level=ERROR msg="Could not establish connection with proxy" bindAddr=localhost:3332 status-code=403
time=2024-02-29T16:03:07.471-03:00 level=ERROR msg="Could not establish connection with proxy" bindAddr=localhost:3334 status-code=403
time=2024-02-29T16:03:07.472-03:00 level=ERROR msg="Could not establish connection with proxy" bindAddr=localhost:3333 status-code=403
time=2024-02-29T16:03:07.473-03:00 level=ERROR msg="Could not establish connection with proxy" bindAddr=localhost:3332 status-code=403
time=2024-02-29T16:03:07.474-03:00 level=ERROR msg="Could not establish connection with proxy" bindAddr=localhost:3334 status-code=403
...
```

After:

```bash
$ signadot local proxy --cluster signadot-staging    --map "http://location.hotrod-devmesh:8081|localhost:3332"    --map "grpc://route.hotrod-devmesh:8083|localhost:3333"    --map "tcp://mysql.hotrod-devmesh:3306|localhost:3334"
Error: 400 Bad Request: could not get cluster "signadot-staging": not found
```