### PR TITLE
only disconnect for cluster connection issue, not sandbox issues

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -369,10 +369,6 @@ github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUz
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/signadot/go-sdk v0.3.8-0.20231120112931-5aa0810b12b7 h1:PgIayNxGde2TvVYCFOsDVZ65WsrBdlh6MN3tzHGeXtM=
 github.com/signadot/go-sdk v0.3.8-0.20231120112931-5aa0810b12b7/go.mod h1:mLzoMuSE0GsFLONRjjYYHQBsU9twXML1BrExSvpMqeI=
-github.com/signadot/libconnect v0.1.1-0.20240227161427-150ab137d426 h1:JNj/feEQ7tDhJhAjLYRa58YIXYX/1dNQi5wh75wOTLg=
-github.com/signadot/libconnect v0.1.1-0.20240227161427-150ab137d426/go.mod h1:qkE8FH3HMF2kD0IK6KcKmKhI8qSQBAuDNEHG7m/9xBc=
-github.com/signadot/libconnect v0.1.1-0.20240228110444-913406aa247b h1:50X5e3fqUPyRBAKzKMPjw68JDp2hm9jZfZy8aZS6JSw=
-github.com/signadot/libconnect v0.1.1-0.20240228110444-913406aa247b/go.mod h1:qkE8FH3HMF2kD0IK6KcKmKhI8qSQBAuDNEHG7m/9xBc=
 github.com/signadot/libconnect v0.1.1-0.20240228132320-61a0d4623d5c h1:3YgE+hXralJW2mVSrip1KNlKICjkv32s/xK2yNg/H40=
 github.com/signadot/libconnect v0.1.1-0.20240228132320-61a0d4623d5c/go.mod h1:qkE8FH3HMF2kD0IK6KcKmKhI8qSQBAuDNEHG7m/9xBc=
 github.com/sirupsen/logrus v1.4.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=

--- a/internal/command/local/connect.go
+++ b/internal/command/local/connect.go
@@ -74,12 +74,6 @@ func runConnect(cmd *cobra.Command, out io.Writer, cfg *config.LocalConnect, arg
 		connConfig.KubeConfigPath = &kcp
 	}
 
-	// Get control-plane proxy url
-	proxyURL, err := cfg.GetProxyURL()
-	if err != nil {
-		return err
-	}
-
 	// compute ConnectInvocationConfig
 	ciConfig := &config.ConnectInvocationConfig{
 		WithRootManager: !cfg.Unprivileged,
@@ -95,7 +89,7 @@ func runConnect(cmd *cobra.Command, out io.Writer, cfg *config.LocalConnect, arg
 			Username: user.Username,
 		},
 		ConnectionConfig: connConfig,
-		ProxyURL:         proxyURL,
+		ProxyURL:         cfg.ProxyURL,
 		APIKey:           cfg.GetAPIKey(),
 		Debug:            cfg.LocalConfig.Debug,
 	}


### PR DESCRIPTION
Upon `local connect` and reconnecting to a broken sandbox, this now gives the below
instead of failing to connect.

I think this is nicer to use, but it also makes the e2e usage of the cli less reliable.

(It seemed spinners aren't particularly well suited to this)

```
24-02-29 scott@air cli % ./signadot local connect
signadot local connect needs root privileges for:
        - updating /etc/hosts with cluster service names
        - configuring networking to direct local traffic to the cluster

signadot local connect has been started ✓
* runtime config: cluster minikube, running with root-daemon
✓ Local connection healthy!
    * operator version 0.15.1-web.5
    * port-forward listening at ":50306"
    * localnet has been configured
    * 24 hosts accessible via /etc/hosts
    * sandboxes watcher is running
* Connected Sandboxes:
    - scott-hotrod-frontend
        * Routing Key: d6mthk3lw8g8g
        - local-frontend: routing from Deployment/frontend in namespace "hotrod"
        ✗ connection not ready
Successfully connected to cluster but some sandboxes are not ready.
```