### PR TITLE
Check version skew in local connect

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/signadot/cli
 go 1.21
 
 require (
+	github.com/Masterminds/semver v1.5.0
 	github.com/docker/go-units v0.5.0
 	github.com/go-openapi/runtime v0.26.0
 	github.com/go-openapi/strfmt v0.21.7

--- a/go.sum
+++ b/go.sum
@@ -58,6 +58,8 @@ github.com/Azure/go-autorest/tracing v0.6.0 h1:TYi4+3m5t6K48TGI9AUdb+IzbnSxvnvUM
 github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
+github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
@@ -369,10 +371,6 @@ github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUz
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/signadot/go-sdk v0.3.8-0.20231120112931-5aa0810b12b7 h1:PgIayNxGde2TvVYCFOsDVZ65WsrBdlh6MN3tzHGeXtM=
 github.com/signadot/go-sdk v0.3.8-0.20231120112931-5aa0810b12b7/go.mod h1:mLzoMuSE0GsFLONRjjYYHQBsU9twXML1BrExSvpMqeI=
-github.com/signadot/libconnect v0.1.1-0.20240227161427-150ab137d426 h1:JNj/feEQ7tDhJhAjLYRa58YIXYX/1dNQi5wh75wOTLg=
-github.com/signadot/libconnect v0.1.1-0.20240227161427-150ab137d426/go.mod h1:qkE8FH3HMF2kD0IK6KcKmKhI8qSQBAuDNEHG7m/9xBc=
-github.com/signadot/libconnect v0.1.1-0.20240228110444-913406aa247b h1:50X5e3fqUPyRBAKzKMPjw68JDp2hm9jZfZy8aZS6JSw=
-github.com/signadot/libconnect v0.1.1-0.20240228110444-913406aa247b/go.mod h1:qkE8FH3HMF2kD0IK6KcKmKhI8qSQBAuDNEHG7m/9xBc=
 github.com/signadot/libconnect v0.1.1-0.20240228132320-61a0d4623d5c h1:3YgE+hXralJW2mVSrip1KNlKICjkv32s/xK2yNg/H40=
 github.com/signadot/libconnect v0.1.1-0.20240228132320-61a0d4623d5c/go.mod h1:qkE8FH3HMF2kD0IK6KcKmKhI8qSQBAuDNEHG7m/9xBc=
 github.com/sirupsen/logrus v1.4.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=

--- a/internal/command/local/connect.go
+++ b/internal/command/local/connect.go
@@ -8,16 +8,20 @@ import (
 	"os/exec"
 	"os/user"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"log/slog"
 
+	"github.com/Masterminds/semver"
 	"github.com/fatih/color"
 	"github.com/signadot/cli/internal/config"
 	sbmapi "github.com/signadot/cli/internal/locald/api/sandboxmanager"
 	sbmgr "github.com/signadot/cli/internal/locald/sandboxmanager"
 	"github.com/signadot/cli/internal/utils/system"
+	clusters "github.com/signadot/go-sdk/client/cluster"
 	"github.com/signadot/libconnect/common/processes"
+	connectcfg "github.com/signadot/libconnect/config"
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/yaml"
 )
@@ -120,6 +124,11 @@ func runConnectImpl(out io.Writer, log *slog.Logger, localConfig *config.LocalCo
 	}
 	if isRunning {
 		return fmt.Errorf("signadot is already connected\n")
+	}
+
+	// Check version skew
+	if err := checkVersionSkew(localConfig, ciConfig); err != nil {
+		return err
 	}
 
 	// Run signadot locald
@@ -262,6 +271,40 @@ doneWaiting:
 		return fmt.Errorf("unable to disconnect failing connect: %w", err)
 	}
 	return fmt.Errorf("connect failed and is no longer running")
+}
+
+func checkVersionSkew(localConfig *config.LocalConnect, ciConfig *config.ConnectInvocationConfig) error {
+	// get the cluster from API
+	params := clusters.NewGetClusterParams().
+		WithOrgName(localConfig.Org).WithClusterName(ciConfig.ConnectionConfig.Cluster)
+	clusterInfo, err := localConfig.Client.Cluster.GetCluster(params, nil)
+	if err != nil {
+		return fmt.Errorf("error reading cluster, %w", err)
+	}
+	if clusterInfo.Payload.Operator == nil {
+		return fmt.Errorf("cluster=%s has never connected with Signadot control-plane",
+			ciConfig.ConnectionConfig.Cluster)
+	}
+
+	// parse the operator version
+	operatorVer, err := semver.NewVersion(strings.Split(clusterInfo.Payload.Operator.Version, " ")[0])
+	if err != nil {
+		return fmt.Errorf("error parsing cluster operator version, %w", err)
+	}
+
+	if ciConfig.ConnectionConfig.Type == connectcfg.ControlPlaneProxyLinkType {
+		// ControlPlaneProxy requires operator > 0.15.0, in the constraint below
+		// we use "> 0.15.1-0" instead of ">= 0.16.0" to catch our pre-release
+		// versions
+		cppConstraint, err := semver.NewConstraint("> 0.15.1-0")
+		if err != nil {
+			return err // this shouldn't happen
+		}
+		if !cppConstraint.Check(operatorVer) {
+			return fmt.Errorf("The connection type ControlPlaneProxy requires operator > v0.15.0")
+		}
+	}
+	return nil
 }
 
 func getLogger(ciConfig *config.ConnectInvocationConfig) (*slog.Logger, error) {

--- a/internal/command/local/proxy.go
+++ b/internal/command/local/proxy.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/oklog/run"
 	"github.com/signadot/cli/internal/config"
+	clusters "github.com/signadot/go-sdk/client/cluster"
 	routegroups "github.com/signadot/go-sdk/client/route_groups"
 	"github.com/signadot/go-sdk/client/sandboxes"
 	"github.com/signadot/libconnect/common/controlplaneproxy"
@@ -67,6 +68,12 @@ func runProxy(cmd *cobra.Command, out io.Writer, cfg *config.LocalProxy, args []
 		cluster = resp.Payload.Spec.Cluster
 		routingKey = resp.Payload.RoutingKey
 	} else {
+		// validate the cluster
+		params := clusters.NewGetClusterParams().
+			WithOrgName(cfg.Org).WithClusterName(cfg.Cluster)
+		if _, err := cfg.Client.Cluster.GetCluster(params, nil); err != nil {
+			return err
+		}
 		cluster = cfg.Cluster
 	}
 


### PR DESCRIPTION
E.g.:

```bash
$ signadot local connect
Error: The connection type ControlPlaneProxy requires operator > v0.15.0
```
