### PR TITLE
Refactor of job logs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/nsf/jsondiff v0.0.0-20210926074059-1e845ec5d249
 	github.com/oklog/run v1.1.0
 	github.com/panta/machineid v1.0.2
-	github.com/signadot/go-sdk v0.3.8-0.20240611124809-9492d65a3b5c
+	github.com/signadot/go-sdk v0.3.8-0.20240612140005-9c306a9dc373
 	github.com/signadot/libconnect v0.1.1-0.20240306100356-4c865b888453
 	github.com/spf13/cobra v1.6.0
 	github.com/spf13/viper v1.11.0
@@ -121,5 +121,4 @@ require (
 
 // Used for local dev
 // replace github.com/signadot/libconnect => ../libconnect/
-
-//replace github.com/signadot/go-sdk => ../go-sdk
+// replace github.com/signadot/go-sdk => ../go-sdk

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/signadot/cli
 
-go 1.21
+go 1.21.0
+
+toolchain go1.21.3
 
 require (
 	github.com/Masterminds/semver v1.5.0
@@ -10,11 +12,11 @@ require (
 	github.com/goccy/go-yaml v1.10.0
 	github.com/golang/protobuf v1.5.4
 	github.com/hashicorp/go-multierror v1.1.1
+	github.com/jclem/sseparser v0.5.0
 	github.com/nsf/jsondiff v0.0.0-20210926074059-1e845ec5d249
 	github.com/oklog/run v1.1.0
 	github.com/panta/machineid v1.0.2
-	github.com/r3labs/sse/v2 v2.10.0
-	github.com/signadot/go-sdk v0.3.8-0.20240529233641-955e0237e964
+	github.com/signadot/go-sdk v0.3.8-0.20240611124809-9492d65a3b5c
 	github.com/signadot/libconnect v0.1.1-0.20240306100356-4c865b888453
 	github.com/spf13/cobra v1.6.0
 	github.com/spf13/viper v1.11.0
@@ -39,9 +41,9 @@ require (
 	github.com/Azure/go-autorest/tracing v0.6.0 // indirect
 	github.com/golang-jwt/jwt/v4 v4.2.0 // indirect
 	github.com/mwitkow/grpc-proxy v0.0.0-20230212185441-f345521cb9c9 // indirect
+	github.com/prataprc/goparsec v0.0.0-20211219142520-daac0e635e7e // indirect
 	golang.org/x/sync v0.7.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240304212257-790db918fca8 // indirect
-	gopkg.in/cenkalti/backoff.v1 v1.1.0 // indirect
 	k8s.io/kubectl v0.25.12 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -302,10 +302,8 @@ github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDNXVBh4M=
 github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUzkipdSkR5nkCZA=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/signadot/go-sdk v0.3.8-0.20240529233641-955e0237e964 h1:S8mXSuI/JcNTkaoXL2L0HDLGgakKffmMMswmZwrLSmM=
-github.com/signadot/go-sdk v0.3.8-0.20240529233641-955e0237e964/go.mod h1:LBc3zdVqtLQpXo78HN/DrMhf6PBcfyhlg/tVRrDL+sg=
-github.com/signadot/go-sdk v0.3.8-0.20240611124809-9492d65a3b5c h1:M3EQRojzAYlFzTncRni3UGX56/qfrH4EHOZ3eJSm4og=
-github.com/signadot/go-sdk v0.3.8-0.20240611124809-9492d65a3b5c/go.mod h1:LBc3zdVqtLQpXo78HN/DrMhf6PBcfyhlg/tVRrDL+sg=
+github.com/signadot/go-sdk v0.3.8-0.20240612140005-9c306a9dc373 h1:Lalacny/LWwQh7/s9Cxg8wBYOsjE/uyOL9ZZwqBiai0=
+github.com/signadot/go-sdk v0.3.8-0.20240612140005-9c306a9dc373/go.mod h1:LBc3zdVqtLQpXo78HN/DrMhf6PBcfyhlg/tVRrDL+sg=
 github.com/signadot/libconnect v0.1.1-0.20240306100356-4c865b888453 h1:omG9Iuz5vO0wNvpX/o1sAu+yuHnjHp6okvV9dDRCcd4=
 github.com/signadot/libconnect v0.1.1-0.20240306100356-4c865b888453/go.mod h1:hS/87oYNXxPg5+sSQuHnQgc8q1xEsBIExnbLEeC46+8=
 github.com/spf13/afero v1.9.5 h1:stMpOSZFs//0Lv29HduCmli3GUfpFoF3Y1Q/aXj/wVM=

--- a/go.sum
+++ b/go.sum
@@ -224,6 +224,8 @@ github.com/imdario/mergo v0.3.6 h1:xTNEAn+kxVO7dTZGu0CegyqKZmoWFI0rF8UxjlB2d28=
 github.com/imdario/mergo v0.3.6/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/inconshreveable/mousetrap v1.0.1 h1:U3uMjPSQEBMNp1lFxmllqCPM6P5u/Xq7Pgzkat/bFNc=
 github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/jclem/sseparser v0.5.0 h1:DcD6ZnzqnAqdUqjamc1nhGLSQRLbTXNYRF9NwdAYpEs=
+github.com/jclem/sseparser v0.5.0/go.mod h1:XpIEwYl1LibAWsx7fxHD61/wBuuVmkRPZ/PBChZ97yU=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
@@ -291,9 +293,9 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pkg/sftp v1.13.1/go.mod h1:3HaPG6Dq1ILlpPZRO0HVMrsydcdLt6HRDccSgb87qRg=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/prataprc/goparsec v0.0.0-20211219142520-daac0e635e7e h1:7teoyCCMBovX+/L3/C2adcGNJI6Tsx6a2hbWQ8vWoO8=
+github.com/prataprc/goparsec v0.0.0-20211219142520-daac0e635e7e/go.mod h1:YbpxZqbf10o5u96/iDpcfDQmbIOTX/iNCH/yBByTfaM=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
-github.com/r3labs/sse/v2 v2.10.0 h1:hFEkLLFY4LDifoHdiCN/LlGBAdVJYsANaLqNYa1l/v0=
-github.com/r3labs/sse/v2 v2.10.0/go.mod h1:Igau6Whc+F17QUgML1fYe1VPZzTV6EMCnYktEmkNJ7I=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
@@ -302,6 +304,8 @@ github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUz
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/signadot/go-sdk v0.3.8-0.20240529233641-955e0237e964 h1:S8mXSuI/JcNTkaoXL2L0HDLGgakKffmMMswmZwrLSmM=
 github.com/signadot/go-sdk v0.3.8-0.20240529233641-955e0237e964/go.mod h1:LBc3zdVqtLQpXo78HN/DrMhf6PBcfyhlg/tVRrDL+sg=
+github.com/signadot/go-sdk v0.3.8-0.20240611124809-9492d65a3b5c h1:M3EQRojzAYlFzTncRni3UGX56/qfrH4EHOZ3eJSm4og=
+github.com/signadot/go-sdk v0.3.8-0.20240611124809-9492d65a3b5c/go.mod h1:LBc3zdVqtLQpXo78HN/DrMhf6PBcfyhlg/tVRrDL+sg=
 github.com/signadot/libconnect v0.1.1-0.20240306100356-4c865b888453 h1:omG9Iuz5vO0wNvpX/o1sAu+yuHnjHp6okvV9dDRCcd4=
 github.com/signadot/libconnect v0.1.1-0.20240306100356-4c865b888453/go.mod h1:hS/87oYNXxPg5+sSQuHnQgc8q1xEsBIExnbLEeC46+8=
 github.com/spf13/afero v1.9.5 h1:stMpOSZFs//0Lv29HduCmli3GUfpFoF3Y1Q/aXj/wVM=
@@ -414,7 +418,6 @@ golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190628185345-da137c7871d7/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190724013045-ca1201d0de80/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
-golang.org/x/net v0.0.0-20191116160921-f9c825593386/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200114155413-6afb5195e5aa/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
@@ -690,8 +693,6 @@ google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp0
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
 google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
-gopkg.in/cenkalti/backoff.v1 v1.1.0 h1:Arh75ttbsvlpVA7WtVpH4u9h6Zl46xuptxqLxPiSo4Y=
-gopkg.in/cenkalti/backoff.v1 v1.1.0/go.mod h1:J6Vskwqd+OMVJl8C33mmtxTBs2gyzfv7UDAkHu8BrjI=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/internal/command/jobrunnergroup/printers.go
+++ b/internal/command/jobrunnergroup/printers.go
@@ -57,5 +57,8 @@ func printRunnerGroupDetails(cfg *config.JobRunnerGroup, out io.Writer, rg *mode
 }
 
 func readiness(status *models.JobRunnerGroupStatus) string {
+	if status == nil || status.Pods == nil {
+		return "-"
+	}
 	return fmt.Sprintf("%d/%d pods ready", status.Pods.Ready, status.Pods.Ready+status.Pods.NotReady)
 }

--- a/internal/command/jobs/printers.go
+++ b/internal/command/jobs/printers.go
@@ -52,11 +52,7 @@ func printJobTable(cfg *config.JobList, out io.Writer, jobs []*models.Job) error
 		if counter == MaxJobListing {
 			break
 		}
-
-		switch {
-		case cfg.ShowAll:
-		case !cfg.ShowAll && job.Status.Phase != "completed" && job.Status.Phase != "canceled":
-		default:
+		if !cfg.ShowAll && !isJobPhaseToPrintDefault(job.Status.Phase) {
 			continue
 		}
 
@@ -76,6 +72,19 @@ func printJobTable(cfg *config.JobList, out io.Writer, jobs []*models.Job) error
 		})
 	}
 	return t.Flush()
+}
+
+func isJobPhaseToPrintDefault(ph string) bool {
+	if ph == "failed" {
+		return false
+	}
+	if ph == "succeeded" {
+		return false
+	}
+	if ph == "canceled" {
+		return false
+	}
+	return true
 }
 
 func printJobDetails(cfg *config.Job, out io.Writer, job *models.Job) error {

--- a/internal/command/logs/command.go
+++ b/internal/command/logs/command.go
@@ -62,16 +62,22 @@ func display(ctx context.Context, cfg *config.Logs, out io.Writer) error {
 	// create a pipe for consuming the SSE stream
 	reader, writer := io.Pipe()
 
-	return cfg.APIClientWithCustomTransport(
-		cfg.OverrideTransportClientConsumers(map[string]runtime.Consumer{
-			"text/event-stream": runtime.ByteStreamConsumer(),
-		}),
+	// create a custom transport to treat text/event-stream as a byte stream
+	transportCfg := cfg.GetBaseTransport()
+	transportCfg.Consumers = map[string]runtime.Consumer{
+		"text/event-stream": runtime.ByteStreamConsumer(),
+	}
+
+	return cfg.APIClientWithCustomTransport(transportCfg,
 		func(c *client.SignadotAPI) error {
 			errch := make(chan error)
 
 			go func() {
 				// parse the SSE stream
 				err := parseSSEStream(reader, out)
+				if errors.Is(err, io.ErrClosedPipe) {
+					err = nil // ignore ErrClosedPipe error
+				}
 				reader.Close()
 				errch <- err
 			}()
@@ -79,6 +85,9 @@ func display(ctx context.Context, cfg *config.Logs, out io.Writer) error {
 			go func() {
 				// read the SSE stream
 				_, err := c.JobLogs.StreamJobAttemptLogs(params, nil, writer)
+				if errors.Is(err, io.ErrClosedPipe) {
+					err = nil // ignore ErrClosedPipe error
+				}
 				writer.Close()
 				errch <- err
 			}()

--- a/internal/config/api.go
+++ b/internal/config/api.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/go-openapi/runtime"
+
 	"github.com/signadot/cli/internal/buildinfo"
 	"github.com/signadot/go-sdk/client"
 	"github.com/signadot/go-sdk/transport"
@@ -86,7 +86,6 @@ func (a *API) init() error {
 }
 
 func (a *API) InitAPIConfig() error {
-
 	if err := a.init(); err != nil {
 		return err
 	}
@@ -94,7 +93,7 @@ func (a *API) InitAPIConfig() error {
 	return a.InitAPITransport()
 }
 
-func (a *API) getBaseTransport() *transport.APIConfig {
+func (a *API) GetBaseTransport() *transport.APIConfig {
 	return &transport.APIConfig{
 		APIKey:          a.ApiKey,
 		APIURL:          a.APIURL,
@@ -106,7 +105,7 @@ func (a *API) getBaseTransport() *transport.APIConfig {
 
 func (a *API) InitAPITransport() error {
 	// init API transport
-	t, err := transport.InitAPITransport(a.getBaseTransport())
+	t, err := transport.InitAPITransport(a.GetBaseTransport())
 	if err != nil {
 		return err
 	}
@@ -116,21 +115,15 @@ func (a *API) InitAPITransport() error {
 	return nil
 }
 
-func (a *API) APIClientWithCustomTransport(conf *transport.APIConfig, execute func(client *client.SignadotAPI) error) error {
+func (a *API) APIClientWithCustomTransport(conf *transport.APIConfig,
+	execute func(client *client.SignadotAPI) error) error {
 	if err := a.init(); err != nil {
-		return nil
+		return err
 	}
 
 	t, err := transport.InitAPITransport(conf)
 	if err != nil {
 		return err
 	}
-
 	return execute(client.New(t, nil))
-}
-
-func (a *API) OverrideTransportClientConsumers(consumers map[string]runtime.Consumer) *transport.APIConfig {
-	cfg := a.getBaseTransport()
-	cfg.Consumers = consumers
-	return cfg
 }


### PR DESCRIPTION
This PR:

First fixes a panic in JRG list (when a cluster is disconnected):

```bash
$ signadot jrg list
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0xc7965f]

goroutine 1 [running]:
github.com/signadot/cli/internal/command/jobrunnergroup.readiness(...)
	/home/ddv/git/signadot/cli/internal/command/jobrunnergroup/printers.go:60
github.com/signadot/cli/internal/command/jobrunnergroup.printRunnerGroupTable(0xc00022d0e0?, {0x1f6cba0?, 0xc00009c028?}, {0xc00022c040, 0x3, 0x0?})
	/home/ddv/git/signadot/cli/internal/command/jobrunnergroup/printers.go:38 +0x27f
github.com/signadot/cli/internal/command/jobrunnergroup.list(0xc00015f988, {0x1f6cba0, 0xc00009c028})
	/home/ddv/git/signadot/cli/internal/command/jobrunnergroup/list.go:40 +0x1b7
github.com/signadot/cli/internal/command/jobrunnergroup.New.newList.func2(0xc0001d9b00?, {0x2e17140?, 0x4?, 0x1cb516d?})
	/home/ddv/git/signadot/cli/internal/command/jobrunnergroup/list.go:22 +0x2c
github.com/spf13/cobra.(*Command).execute(0xc0002d1800, {0x2e17140, 0x0, 0x0})
	/home/ddv/go/pkg/mod/github.com/spf13/cobra@v1.6.0/command.go:916 +0x87c
github.com/spf13/cobra.(*Command).ExecuteC(0xc0004ff200)
	/home/ddv/go/pkg/mod/github.com/spf13/cobra@v1.6.0/command.go:1040 +0x38d
github.com/spf13/cobra.(*Command).Execute(0xc0000061a0?)
	/home/ddv/go/pkg/mod/github.com/spf13/cobra@v1.6.0/command.go:968 +0x13
main.main()
	/home/ddv/git/signadot/cli/cmd/signadot/main.go:11 +0x18
```

Second, in the context of https://github.com/signadot/signadot/pull/4526, I found the SSE library we were using (`github.com/r3labs/sse/v2`) was performing infinite retries in case of errors, what could lead to the duplication of log lines. I tried to find a way to disabled retries, or at least be more selective about them, but couldn't find a simple way to do it.
This is certainly unexpected, for example, what's the point of retrying when getting an HTTP 404 response? Given this was also forcing us to go outside of the SDK, I decided just to find an SSE parsing library, and use it alongside the SDK, having ultimate control over retries in case we want to implement them in the future. 

