### PR TITLE
Fix download of artifacts

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/nsf/jsondiff v0.0.0-20210926074059-1e845ec5d249
 	github.com/oklog/run v1.1.0
 	github.com/panta/machineid v1.0.2
-	github.com/signadot/go-sdk v0.3.8-0.20240611124809-9492d65a3b5c
+	github.com/signadot/go-sdk v0.3.8-0.20240611190756-f5c5d53dc051
 	github.com/signadot/libconnect v0.1.1-0.20240306100356-4c865b888453
 	github.com/spf13/cobra v1.6.0
 	github.com/spf13/viper v1.11.0

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/nsf/jsondiff v0.0.0-20210926074059-1e845ec5d249
 	github.com/oklog/run v1.1.0
 	github.com/panta/machineid v1.0.2
-	github.com/signadot/go-sdk v0.3.8-0.20240611190756-f5c5d53dc051
+	github.com/signadot/go-sdk v0.3.8-0.20240612140005-9c306a9dc373
 	github.com/signadot/libconnect v0.1.1-0.20240306100356-4c865b888453
 	github.com/spf13/cobra v1.6.0
 	github.com/spf13/viper v1.11.0
@@ -121,5 +121,4 @@ require (
 
 // Used for local dev
 // replace github.com/signadot/libconnect => ../libconnect/
-
-//replace github.com/signadot/go-sdk => ../go-sdk
+// replace github.com/signadot/go-sdk => ../go-sdk

--- a/go.sum
+++ b/go.sum
@@ -302,10 +302,8 @@ github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDNXVBh4M=
 github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUzkipdSkR5nkCZA=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/signadot/go-sdk v0.3.8-0.20240529233641-955e0237e964 h1:S8mXSuI/JcNTkaoXL2L0HDLGgakKffmMMswmZwrLSmM=
-github.com/signadot/go-sdk v0.3.8-0.20240529233641-955e0237e964/go.mod h1:LBc3zdVqtLQpXo78HN/DrMhf6PBcfyhlg/tVRrDL+sg=
-github.com/signadot/go-sdk v0.3.8-0.20240611124809-9492d65a3b5c h1:M3EQRojzAYlFzTncRni3UGX56/qfrH4EHOZ3eJSm4og=
-github.com/signadot/go-sdk v0.3.8-0.20240611124809-9492d65a3b5c/go.mod h1:LBc3zdVqtLQpXo78HN/DrMhf6PBcfyhlg/tVRrDL+sg=
+github.com/signadot/go-sdk v0.3.8-0.20240611190756-f5c5d53dc051 h1:dyumuJMs6hbswMmDYRdyIYwYbEkHvgYzd0dhYrtsTug=
+github.com/signadot/go-sdk v0.3.8-0.20240611190756-f5c5d53dc051/go.mod h1:LBc3zdVqtLQpXo78HN/DrMhf6PBcfyhlg/tVRrDL+sg=
 github.com/signadot/libconnect v0.1.1-0.20240306100356-4c865b888453 h1:omG9Iuz5vO0wNvpX/o1sAu+yuHnjHp6okvV9dDRCcd4=
 github.com/signadot/libconnect v0.1.1-0.20240306100356-4c865b888453/go.mod h1:hS/87oYNXxPg5+sSQuHnQgc8q1xEsBIExnbLEeC46+8=
 github.com/spf13/afero v1.9.5 h1:stMpOSZFs//0Lv29HduCmli3GUfpFoF3Y1Q/aXj/wVM=

--- a/go.sum
+++ b/go.sum
@@ -302,8 +302,8 @@ github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDNXVBh4M=
 github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUzkipdSkR5nkCZA=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/signadot/go-sdk v0.3.8-0.20240611190756-f5c5d53dc051 h1:dyumuJMs6hbswMmDYRdyIYwYbEkHvgYzd0dhYrtsTug=
-github.com/signadot/go-sdk v0.3.8-0.20240611190756-f5c5d53dc051/go.mod h1:LBc3zdVqtLQpXo78HN/DrMhf6PBcfyhlg/tVRrDL+sg=
+github.com/signadot/go-sdk v0.3.8-0.20240612140005-9c306a9dc373 h1:Lalacny/LWwQh7/s9Cxg8wBYOsjE/uyOL9ZZwqBiai0=
+github.com/signadot/go-sdk v0.3.8-0.20240612140005-9c306a9dc373/go.mod h1:LBc3zdVqtLQpXo78HN/DrMhf6PBcfyhlg/tVRrDL+sg=
 github.com/signadot/libconnect v0.1.1-0.20240306100356-4c865b888453 h1:omG9Iuz5vO0wNvpX/o1sAu+yuHnjHp6okvV9dDRCcd4=
 github.com/signadot/libconnect v0.1.1-0.20240306100356-4c865b888453/go.mod h1:hS/87oYNXxPg5+sSQuHnQgc8q1xEsBIExnbLEeC46+8=
 github.com/spf13/afero v1.9.5 h1:stMpOSZFs//0Lv29HduCmli3GUfpFoF3Y1Q/aXj/wVM=

--- a/internal/command/artifact/download.go
+++ b/internal/command/artifact/download.go
@@ -1,11 +1,13 @@
 package artifact
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
 	"path"
 	"strings"
+	"time"
 
 	"github.com/go-openapi/runtime"
 	"github.com/signadot/cli/internal/config"
@@ -22,7 +24,7 @@ func newDownload(artifact *config.Artifact) *cobra.Command {
 		Short: "Download job artifacts",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return download(cfg, cmd.OutOrStdout(), args[0])
+			return download(cmd.Context(), cfg, cmd.OutOrStdout(), args[0])
 		},
 	}
 
@@ -31,7 +33,7 @@ func newDownload(artifact *config.Artifact) *cobra.Command {
 	return cmd
 }
 
-func download(cfg *config.ArtifactDownload, out io.Writer, artifactPath string) error {
+func download(ctx context.Context, cfg *config.ArtifactDownload, out io.Writer, artifactPath string) error {
 	if err := cfg.InitAPIConfig(); err != nil {
 		return err
 	}
@@ -42,9 +44,7 @@ func download(cfg *config.ArtifactDownload, out io.Writer, artifactPath string) 
 		return err
 	}
 
-	/*
-		If path starts with @ means is system based, otherwise user
-	*/
+	// If path starts with @ means is system based, otherwise user
 	space := "user"
 	if strings.HasPrefix(artifactPath, "@") {
 		space = "system"
@@ -53,15 +53,22 @@ func download(cfg *config.ArtifactDownload, out io.Writer, artifactPath string) 
 
 	params := artifacts.
 		NewDownloadJobAttemptArtifactParams().
+		WithContext(ctx).
+		WithTimeout(2 * time.Minute).
 		WithOrgName(cfg.Org).
 		WithJobName(cfg.Job).
 		WithJobAttempt(0).
 		WithPath(artifactPath).
 		WithSpace(&space)
 
-	err = cfg.APIClientWithCustomTransport(cfg.OverrideTransportClientConsumers(map[string]runtime.Consumer{
-		runtime.TextMime: runtime.ByteStreamConsumer(),
-	}),
+	// create a custom transport to treat everything as a byte stream
+	transportCfg := cfg.GetBaseTransport()
+	transportCfg.OverrideConsumers = true
+	transportCfg.Consumers = map[string]runtime.Consumer{
+		"*/*": runtime.ByteStreamConsumer(),
+	}
+
+	return cfg.APIClientWithCustomTransport(transportCfg,
 		func(c *client.SignadotAPI) error {
 			_, _, err = c.Artifacts.DownloadJobAttemptArtifact(params, nil, f)
 			if err != nil {
@@ -69,15 +76,8 @@ func download(cfg *config.ArtifactDownload, out io.Writer, artifactPath string) 
 			}
 
 			fmt.Fprintf(out, "File saved successfully at %s\n", outputFilename)
-
 			return nil
 		})
-
-	if err != nil {
-		return err
-	}
-
-	return nil
 }
 
 func getOutputFilename(cfg *config.ArtifactDownload, artifactPath string) string {

--- a/internal/command/artifact/download.go
+++ b/internal/command/artifact/download.go
@@ -54,7 +54,7 @@ func download(ctx context.Context, cfg *config.ArtifactDownload, out io.Writer, 
 	params := artifacts.
 		NewDownloadJobAttemptArtifactParams().
 		WithContext(ctx).
-		WithTimeout(2 * time.Minute).
+		WithTimeout(4 * time.Minute).
 		WithOrgName(cfg.Org).
 		WithJobName(cfg.Job).
 		WithJobAttempt(0).

--- a/internal/command/jobs/printers.go
+++ b/internal/command/jobs/printers.go
@@ -52,11 +52,7 @@ func printJobTable(cfg *config.JobList, out io.Writer, jobs []*models.Job) error
 		if counter == MaxJobListing {
 			break
 		}
-
-		switch {
-		case cfg.ShowAll:
-		case !cfg.ShowAll && job.Status.Phase != "completed" && job.Status.Phase != "canceled":
-		default:
+		if !cfg.ShowAll && !isJobPhaseToPrintDefault(job.Status.Phase) {
 			continue
 		}
 
@@ -76,6 +72,19 @@ func printJobTable(cfg *config.JobList, out io.Writer, jobs []*models.Job) error
 		})
 	}
 	return t.Flush()
+}
+
+func isJobPhaseToPrintDefault(ph string) bool {
+	if ph == "failed" {
+		return false
+	}
+	if ph == "succeeded" {
+		return false
+	}
+	if ph == "canceled" {
+		return false
+	}
+	return true
 }
 
 func printJobDetails(cfg *config.Job, out io.Writer, job *models.Job) error {

--- a/internal/command/logs/command.go
+++ b/internal/command/logs/command.go
@@ -62,10 +62,13 @@ func display(ctx context.Context, cfg *config.Logs, out io.Writer) error {
 	// create a pipe for consuming the SSE stream
 	reader, writer := io.Pipe()
 
-	return cfg.APIClientWithCustomTransport(
-		cfg.OverrideTransportClientConsumers(map[string]runtime.Consumer{
-			"text/event-stream": runtime.ByteStreamConsumer(),
-		}),
+	// create a custom transport to treat text/event-stream as a byte stream
+	transportCfg := cfg.GetBaseTransport()
+	transportCfg.Consumers = map[string]runtime.Consumer{
+		"text/event-stream": runtime.ByteStreamConsumer(),
+	}
+
+	return cfg.APIClientWithCustomTransport(transportCfg,
 		func(c *client.SignadotAPI) error {
 			errch := make(chan error)
 

--- a/internal/command/logs/command.go
+++ b/internal/command/logs/command.go
@@ -75,6 +75,9 @@ func display(ctx context.Context, cfg *config.Logs, out io.Writer) error {
 			go func() {
 				// parse the SSE stream
 				err := parseSSEStream(reader, out)
+				if errors.Is(err, io.ErrClosedPipe) {
+					err = nil // ignore ErrClosedPipe error
+				}
 				reader.Close()
 				errch <- err
 			}()
@@ -82,6 +85,9 @@ func display(ctx context.Context, cfg *config.Logs, out io.Writer) error {
 			go func() {
 				// read the SSE stream
 				_, err := c.JobLogs.StreamJobAttemptLogs(params, nil, writer)
+				if errors.Is(err, io.ErrClosedPipe) {
+					err = nil // ignore ErrClosedPipe error
+				}
 				writer.Close()
 				errch <- err
 			}()

--- a/internal/config/api.go
+++ b/internal/config/api.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/go-openapi/runtime"
+
 	"github.com/signadot/cli/internal/buildinfo"
 	"github.com/signadot/go-sdk/client"
 	"github.com/signadot/go-sdk/transport"
@@ -86,7 +86,6 @@ func (a *API) init() error {
 }
 
 func (a *API) InitAPIConfig() error {
-
 	if err := a.init(); err != nil {
 		return err
 	}
@@ -94,7 +93,7 @@ func (a *API) InitAPIConfig() error {
 	return a.InitAPITransport()
 }
 
-func (a *API) getBaseTransport() *transport.APIConfig {
+func (a *API) GetBaseTransport() *transport.APIConfig {
 	return &transport.APIConfig{
 		APIKey:          a.ApiKey,
 		APIURL:          a.APIURL,
@@ -106,7 +105,7 @@ func (a *API) getBaseTransport() *transport.APIConfig {
 
 func (a *API) InitAPITransport() error {
 	// init API transport
-	t, err := transport.InitAPITransport(a.getBaseTransport())
+	t, err := transport.InitAPITransport(a.GetBaseTransport())
 	if err != nil {
 		return err
 	}
@@ -116,21 +115,15 @@ func (a *API) InitAPITransport() error {
 	return nil
 }
 
-func (a *API) APIClientWithCustomTransport(conf *transport.APIConfig, execute func(client *client.SignadotAPI) error) error {
+func (a *API) APIClientWithCustomTransport(conf *transport.APIConfig,
+	execute func(client *client.SignadotAPI) error) error {
 	if err := a.init(); err != nil {
-		return nil
+		return err
 	}
 
 	t, err := transport.InitAPITransport(conf)
 	if err != nil {
 		return err
 	}
-
 	return execute(client.New(t, nil))
-}
-
-func (a *API) OverrideTransportClientConsumers(consumers map[string]runtime.Consumer) *transport.APIConfig {
-	cfg := a.getBaseTransport()
-	cfg.Consumers = consumers
-	return cfg
 }


### PR DESCRIPTION
This PR implements the changes described in https://github.com/signadot/cli/pull/124#discussion_r1633829097.
It is stacked on:

- https://github.com/signadot/go-sdk/pull/49 (required changes in the SDK)
- https://github.com/signadot/cli/pull/126 (minor changes in job logs)

E.g.:
```bash
signadot artifact download --job hotrod-cypress-e2e-ivjkk3y hotrod/cypress/videos/hotrod.cy.js.mp4 -o /tmp/hotrod.cy.js.mp4
File saved successfully at /tmp/hotrod.cy.js.mp4

signadot artifact download --job hotrod-cypress-e2e-ivjkk3y @stdout -o /tmp/stdout
File saved successfully at /tmp/stdout
```
