### PR TITLE
add check to access agent-metrics endpoint

### DIFF
--- a/internal/locald/rootmanager/tp_monitor.go
+++ b/internal/locald/rootmanager/tp_monitor.go
@@ -134,7 +134,7 @@ func (mon *tpMonitor) checkTunnelProxyAccess(ctx context.Context) bool {
 		if rootMgr == nil {
 			return false
 		}
-		if rootMgr.localnetSVC == nil || rootMgr.localnetSVC.Status().Healthy {
+		if rootMgr.localnetSVC == nil || !rootMgr.localnetSVC.Status().Healthy {
 			return false
 		}
 		if rootMgr.etcHostsSVC == nil || !rootMgr.etcHostsSVC.Status().Healthy {

--- a/internal/locald/rootmanager/tp_monitor.go
+++ b/internal/locald/rootmanager/tp_monitor.go
@@ -130,11 +130,16 @@ func (mon *tpMonitor) checkTunnelProxyAccess(ctx context.Context) bool {
 		}
 	}
 	if !restartSvcs {
-		if mon.root == nil || mon.root.root == nil || mon.root.root.etcHostsSVC == nil || !mon.root.root.etcHostsSVC.Status().Healthy {
+		rootMgr := mon.root.root
+		if rootMgr == nil {
 			return false
 		}
-	}
-	if !restartSvcs {
+		if rootMgr.localnetSVC == nil || rootMgr.localnetSVC.Status().Healthy {
+			return false
+		}
+		if rootMgr.etcHostsSVC == nil || !rootMgr.etcHostsSVC.Status().Healthy {
+			return false
+		}
 		// the grpc check for connecting to the tunnel proxy does not suffice
 		// because it has built-in retries and may re-use a connection while
 		// we are unable to establish a new connection.  So, we also check

--- a/internal/locald/sandboxmanager/sdk.go
+++ b/internal/locald/sandboxmanager/sdk.go
@@ -17,7 +17,7 @@ import (
 
 var (
 	ErrSandboxManagerUnavailable = errors.New(
-		"sandboxmanager is not running, start it with \"signadot local connect\"")
+		`sandboxmanager is not running, start it with "signadot local connect"`)
 )
 
 func GetStatus() (*sbmapi.StatusResponse, error) {


### PR DESCRIPTION
This is intended as minimal change to fix

https://github.com/signadot/signadot/issues/5172

tested with warp, it causes restarts and we are able to connect whereas previously it hangs

regarding discussion around:

- do we need to make this visible in status?
I changed it so that it is more visible in status, returning unhealthy when a restart is needed instead of healthy.

- do we need to make check period configurable?

I think not, because it is actually complicated because there 2 check periods for healthy and unhealthy state.  Also, the check period relates to the timeout for the added checking request.



