### PR TITLE
addition of `signadot job submit -f ... --wait`

### DIFF
--- a/internal/command/jobs/submit.go
+++ b/internal/command/jobs/submit.go
@@ -76,8 +76,13 @@ func submit(ctx context.Context, cfg *config.JobSubmit, outW, errW io.Writer) er
 
 func waitJob(ctx context.Context, cfg *config.JobSubmit, name string) (*models.Job, error) {
 
-	ticker := time.NewTicker(time.Second / 5)
+	ticker := time.NewTicker(time.Second)
 	defer ticker.Stop()
+	if cfg.Timeout != 0 {
+		ctxTimeout, cancel := context.WithTimeout(ctx, cfg.Timeout)
+		defer cancel()
+		ctx = ctxTimeout
+	}
 	params := &jobs.GetJobParams{
 		JobName: name,
 		OrgName: cfg.Org,

--- a/internal/config/job.go
+++ b/internal/config/job.go
@@ -26,7 +26,7 @@ func (c *JobSubmit) AddFlags(cmd *cobra.Command) {
 	cmd.MarkFlagRequired("filename")
 	cmd.Flags().Var(&c.TemplateVals, "set", "--set var=val")
 	cmd.Flags().BoolVar(&c.Attach, "attach", false, "waits until the job is completed, displaying the stdout and stderr streams")
-	cmd.Flags().DurationVar(&c.Timeout, "timeout", 0, "timeout when waiting for the job to be started, if 0 is specified, no timeout will be applied and the command will wait until completion or cancellation of the job (default 0)")
+	cmd.Flags().DurationVar(&c.Timeout, "timeout", 0, "timeout when waiting for the job, if 0 is specified, no timeout will be applied and the command will wait until completion or cancellation of the job (default 0)")
 	cmd.Flags().BoolVar(&c.Wait, "wait", false, "waits until the job is completed")
 }
 

--- a/internal/config/job.go
+++ b/internal/config/job.go
@@ -18,6 +18,7 @@ type JobSubmit struct {
 	Attach       bool
 	Timeout      time.Duration
 	TemplateVals TemplateVals
+	Wait         bool
 }
 
 func (c *JobSubmit) AddFlags(cmd *cobra.Command) {
@@ -26,6 +27,7 @@ func (c *JobSubmit) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().Var(&c.TemplateVals, "set", "--set var=val")
 	cmd.Flags().BoolVar(&c.Attach, "attach", false, "waits until the job is completed, displaying the stdout and stderr streams")
 	cmd.Flags().DurationVar(&c.Timeout, "timeout", 0, "timeout when waiting for the job to be started, if 0 is specified, no timeout will be applied and the command will wait until completion or cancellation of the job (default 0)")
+	cmd.Flags().BoolVar(&c.Wait, "wait", false, "waits until the job is completed")
 }
 
 type JobDelete struct {


### PR DESCRIPTION
```
24-12-30 scott@air cli % cat ~/tmp/job.yaml
spec:
  namePrefix: jwait
  runnerGroup: scott-jrg
  script: |
    #!/bin/sh
    echo not exiting-28
24-12-30 scott@air cli % ./signadot job submit -f ~/tmp/job.yaml --wait
Job jwait-lfl0zyi succeeded on Job Runner Group: scott-jrg

Dashboard page: https://app.signadot.com/testing/jobs/jwait-lfl0zyi

24-12-30 scott@air cli % echo $?
0
```

```
24-12-30 scott@air cli % cat ~/tmp/job.yaml
spec:
  namePrefix: jwait
  runnerGroup: scott-jrg
  script: |
    #!/bin/sh
    echo exiting-28
    exit 28
24-12-30 scott@air cli % ./signadot job submit -f ~/tmp/job.yaml --wait
Job jwait-k3mbgby failed on Job Runner Group: scott-jrg

Dashboard page: https://app.signadot.com/testing/jobs/jwait-k3mbgby

Error: job "jwait-k3mbgby" failed
24-12-30 scott@air cli % echo $?
1
```

```
24-12-30 scott@air cli % ./signadot job submit -f ~/tmp/job.yaml --wait --attach
Error: cannot specify both --attach and --wait
```
