### PR TITLE
Rename synthetic to hosted-test

### DIFF
--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -7,6 +7,7 @@ import (
 	"github.com/signadot/cli/internal/command/artifact"
 	"github.com/signadot/cli/internal/command/bug"
 	"github.com/signadot/cli/internal/command/cluster"
+	"github.com/signadot/cli/internal/command/hostedtest"
 	"github.com/signadot/cli/internal/command/jobrunnergroup"
 	"github.com/signadot/cli/internal/command/jobs"
 	"github.com/signadot/cli/internal/command/local"
@@ -15,7 +16,6 @@ import (
 	"github.com/signadot/cli/internal/command/resourceplugin"
 	"github.com/signadot/cli/internal/command/routegroup"
 	"github.com/signadot/cli/internal/command/sandbox"
-	"github.com/signadot/cli/internal/command/synthetic"
 	"github.com/signadot/cli/internal/command/test"
 	"github.com/signadot/cli/internal/config"
 	"github.com/spf13/cobra"
@@ -52,7 +52,7 @@ func New() *cobra.Command {
 		test.New(cfg),
 
 		// hidden commands
-		synthetic.New(cfg),
+		hostedtest.New(cfg),
 	)
 
 	return cmd

--- a/internal/command/hostedtest/apply.go
+++ b/internal/command/hostedtest/apply.go
@@ -1,4 +1,4 @@
-package synthetic
+package hostedtest
 
 import (
 	"encoding/json"
@@ -15,13 +15,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newApply(testConfig *config.Synthetic) *cobra.Command {
-	cfg := &config.SyntheticApply{
-		Synthetic: testConfig,
+func newApply(testConfig *config.HostedTest) *cobra.Command {
+	cfg := &config.HostedTestApply{
+		HostedTest: testConfig,
 	}
 	cmd := &cobra.Command{
 		Use:   "apply -f FILENAME [ --set var1=val1 --set var2=val2 ... ]",
-		Short: "Create or update a synthetic test with variable expansion",
+		Short: "Create or update a hosted test with variable expansion",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return apply(cfg, cmd.OutOrStdout(), cmd.ErrOrStderr(), args)
@@ -31,7 +31,7 @@ func newApply(testConfig *config.Synthetic) *cobra.Command {
 	return cmd
 }
 
-func apply(cfg *config.SyntheticApply, wOut, wErr io.Writer, args []string) error {
+func apply(cfg *config.HostedTestApply, wOut, wErr io.Writer, args []string) error {
 	if err := cfg.InitAPIConfig(); err != nil {
 		return err
 	}

--- a/internal/command/hostedtest/command.go
+++ b/internal/command/hostedtest/command.go
@@ -1,4 +1,4 @@
-package synthetic
+package hostedtest
 
 import (
 	"github.com/signadot/cli/internal/config"
@@ -6,11 +6,11 @@ import (
 )
 
 func New(api *config.API) *cobra.Command {
-	cfg := &config.Synthetic{API: api}
+	cfg := &config.HostedTest{API: api}
 	cmd := &cobra.Command{
-		Use:     "synthetic",
-		Short:   "Signadot synthetic tests",
-		Aliases: []string{"st"},
+		Use:     "hosted-test",
+		Short:   "Signadot hosted tests",
+		Aliases: []string{"ht"},
 		Hidden:  true,
 	}
 

--- a/internal/command/hostedtest/delete.go
+++ b/internal/command/hostedtest/delete.go
@@ -1,4 +1,4 @@
-package synthetic
+package hostedtest
 
 import (
 	"errors"
@@ -11,13 +11,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newDelete(tstConfig *config.Synthetic) *cobra.Command {
-	cfg := &config.SyntheticDelete{
-		Synthetic: tstConfig,
+func newDelete(tstConfig *config.HostedTest) *cobra.Command {
+	cfg := &config.HostedTestDelete{
+		HostedTest: tstConfig,
 	}
 	cmd := &cobra.Command{
-		Use:   "delete <name>",
-		Short: "Delete a synthetic test",
+		Use:   "delete <n>",
+		Short: "Delete a hosted test",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return deleteTest(cfg, cmd.OutOrStdout(), cmd.ErrOrStderr(), args)
@@ -27,7 +27,7 @@ func newDelete(tstConfig *config.Synthetic) *cobra.Command {
 	return cmd
 }
 
-func deleteTest(cfg *config.SyntheticDelete, wOut, wErr io.Writer, args []string) error {
+func deleteTest(cfg *config.HostedTestDelete, wOut, wErr io.Writer, args []string) error {
 	if err := cfg.InitAPIConfig(); err != nil {
 		return err
 	}

--- a/internal/command/hostedtest/get.go
+++ b/internal/command/hostedtest/get.go
@@ -1,4 +1,4 @@
-package synthetic
+package hostedtest
 
 import (
 	"errors"
@@ -9,13 +9,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newGet(tstConfig *config.Synthetic) *cobra.Command {
-	cfg := &config.SyntheticGet{
-		Synthetic: tstConfig,
+func newGet(tstConfig *config.HostedTest) *cobra.Command {
+	cfg := &config.HostedTestGet{
+		HostedTest: tstConfig,
 	}
 	cmd := &cobra.Command{
-		Use:   "get <name>",
-		Short: "Get a synthetic test",
+		Use:   "get <n>",
+		Short: "Get a hosted test",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return get(cfg, cmd.OutOrStdout(), cmd.ErrOrStderr(), args)
@@ -25,7 +25,7 @@ func newGet(tstConfig *config.Synthetic) *cobra.Command {
 	return cmd
 }
 
-func get(cfg *config.SyntheticGet, wOut, wErr io.Writer, args []string) error {
+func get(cfg *config.HostedTestGet, wOut, wErr io.Writer, args []string) error {
 	if err := cfg.InitAPIConfig(); err != nil {
 		return err
 	}

--- a/internal/command/hostedtest/list.go
+++ b/internal/command/hostedtest/list.go
@@ -1,4 +1,4 @@
-package synthetic
+package hostedtest
 
 import (
 	"errors"
@@ -13,13 +13,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newList(tstConfig *config.Synthetic) *cobra.Command {
-	cfg := &config.SyntheticList{
-		Synthetic: tstConfig,
+func newList(tstConfig *config.HostedTest) *cobra.Command {
+	cfg := &config.HostedTestList{
+		HostedTest: tstConfig,
 	}
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: "List synthetic tests",
+		Short: "List hosted tests",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return list(cfg, cmd.OutOrStdout(), cmd.ErrOrStderr(), args)
@@ -29,7 +29,7 @@ func newList(tstConfig *config.Synthetic) *cobra.Command {
 	return cmd
 }
 
-func list(cfg *config.SyntheticList, wOut, wErr io.Writer, args []string) error {
+func list(cfg *config.HostedTestList, wOut, wErr io.Writer, args []string) error {
 	if err := cfg.InitAPIConfig(); err != nil {
 		return err
 	}

--- a/internal/command/hostedtest/print.go
+++ b/internal/command/hostedtest/print.go
@@ -1,4 +1,4 @@
-package synthetic
+package hostedtest
 
 import (
 	"fmt"

--- a/internal/command/hostedtest/run.go
+++ b/internal/command/hostedtest/run.go
@@ -1,4 +1,4 @@
-package synthetic
+package hostedtest
 
 import (
 	"errors"
@@ -12,13 +12,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newRun(tConfig *config.Synthetic) *cobra.Command {
-	cfg := &config.SyntheticRun{
-		Synthetic: tConfig,
+func newRun(tConfig *config.HostedTest) *cobra.Command {
+	cfg := &config.HostedTestRun{
+		HostedTest: tConfig,
 	}
 	cmd := &cobra.Command{
-		Use:   "run <name>",
-		Short: "Run a synthetic test",
+		Use:   "run <n>",
+		Short: "Run a hosted test",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return run(cfg, cmd.OutOrStdout(), cmd.ErrOrStderr(), args)
@@ -28,7 +28,7 @@ func newRun(tConfig *config.Synthetic) *cobra.Command {
 	return cmd
 }
 
-func run(cfg *config.SyntheticRun, wOut, wErr io.Writer, args []string) error {
+func run(cfg *config.HostedTestRun, wOut, wErr io.Writer, args []string) error {
 	if err := cfg.InitAPIConfig(); err != nil {
 		return err
 	}

--- a/internal/command/test/command.go
+++ b/internal/command/test/command.go
@@ -11,7 +11,6 @@ func New(api *config.API) *cobra.Command {
 		Use:     "test",
 		Short:   "Signadot tests",
 		Aliases: []string{"t"},
-		Hidden:  true,
 	}
 
 	run := newRun(cfg)

--- a/internal/config/hostedtest.go
+++ b/internal/config/hostedtest.go
@@ -2,49 +2,49 @@ package config
 
 import "github.com/spf13/cobra"
 
-type Synthetic struct {
+type HostedTest struct {
 	*API
 }
 
-type SyntheticApply struct {
-	*Synthetic
+type HostedTestApply struct {
+	*HostedTest
 
 	Filename     string
 	TemplateVals TemplateVals
 }
 
-func (cfg *SyntheticApply) AddFlags(cmd *cobra.Command) {
-	cmd.Flags().StringVarP(&cfg.Filename, "filename", "f", "", "YAML or JSON file containing the synthetic test creation request")
+func (cfg *HostedTestApply) AddFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(&cfg.Filename, "filename", "f", "", "YAML or JSON file containing the hosted test creation request")
 	cmd.MarkFlagRequired("filename")
 	cmd.Flags().Var(&cfg.TemplateVals, "set", "--set var=val")
 }
 
-type SyntheticGet struct {
-	*Synthetic
+type HostedTestGet struct {
+	*HostedTest
 }
 
-type SyntheticList struct {
-	*Synthetic
+type HostedTestList struct {
+	*HostedTest
 
 	// TODO query params
 }
 
-type SyntheticDelete struct {
-	*Synthetic
+type HostedTestDelete struct {
+	*HostedTest
 
 	Filename     string
 	TemplateVals TemplateVals
 }
 
-type SyntheticRun struct {
-	*Synthetic
+type HostedTestRun struct {
+	*HostedTest
 
 	Cluster    string
 	Sandbox    string
 	RouteGroup string
 }
 
-func (cfg *SyntheticRun) AddFlags(cmd *cobra.Command) {
+func (cfg *HostedTestRun) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&cfg.Cluster, "cluster", "c", "", "cluster name (required for test execution)")
 	cmd.Flags().StringVarP(&cfg.Sandbox, "sandbox", "s", "", "sandbox")
 	cmd.Flags().StringVarP(&cfg.RouteGroup, "routegroup", "r", "", "routegroup")


### PR DESCRIPTION
Stacked on https://github.com/signadot/cli/pull/161.

This PR:

* Renames `syntheric` to `hosted-test`
* Makes `test` command public