### PR TITLE
add --set-label to t run and change wait to --no-wait

### DIFF
--- a/internal/command/test/run.go
+++ b/internal/command/test/run.go
@@ -77,7 +77,7 @@ func run(ctx context.Context, cfg *config.TestRun, wOut, wErr io.Writer,
 	}
 
 	var txs []*models.TestExecution
-	if cfg.Wait {
+	if !cfg.NoWait {
 		// wait until all test execution have completed
 		txs, err = waitForTests(ctx, cfg, runID, out)
 		if err != nil {
@@ -95,7 +95,7 @@ func run(ctx context.Context, cfg *config.TestRun, wOut, wErr io.Writer,
 		// render the latest status of test executions
 		out.renderTestXsTable(txs, "")
 
-		if cfg.Wait {
+		if !cfg.NoWait {
 			// render the test executions summary
 			out.renderTestXsSummary(txs)
 		}
@@ -196,6 +196,9 @@ func triggerTests(cfg *config.TestRun, runID string,
 		spec.TestName = tf.Name
 		// define the labels
 		spec.Labels = tf.Labels
+		for k, v := range cfg.Labels {
+			spec.Labels[k] = v
+		}
 		// define the script
 		scriptContent, err := os.ReadFile(tf.Path)
 		if err != nil {

--- a/internal/config/test.go
+++ b/internal/config/test.go
@@ -1,6 +1,10 @@
 package config
 
 import (
+	"bytes"
+	"fmt"
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -15,12 +19,44 @@ type Test struct {
 type TestRun struct {
 	*Test
 	Directory  string
+	Labels     RunLabels
 	Cluster    string
 	Sandbox    string
 	RouteGroup string
 	Publish    bool
 	Timeout    time.Duration
-	Wait       bool
+	NoWait     bool
+}
+
+type RunLabels map[string]string
+
+func (rl RunLabels) String() string {
+	keys := make([]string, 0, len(rl))
+	for k := range rl {
+		keys = append(keys, k)
+	}
+	res := bytes.NewBuffer(nil)
+	sort.Stable(sort.StringSlice(keys))
+	for i, key := range keys {
+		if i != 0 {
+			fmt.Fprintf(res, ",")
+		}
+		fmt.Fprintf(res, "%s:%s", key, rl[key])
+	}
+	return res.String()
+}
+
+func (rl RunLabels) Set(v string) error {
+	key, val, ok := strings.Cut(v, ":")
+	if !ok {
+		return fmt.Errorf("%q should be in form <key>:<value>", v)
+	}
+	rl[key] = val
+	return nil
+}
+
+func (tl RunLabels) Type() string {
+	return "labels"
 }
 
 // AddFlags adds the flags for the test run command
@@ -31,7 +67,10 @@ func (c *TestRun) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&c.RouteGroup, "route-group", "", "Route group where to run tests")
 	cmd.Flags().BoolVar(&c.Publish, "publish", false, "Publish test results")
 	cmd.Flags().DurationVar(&c.Timeout, "timeout", 0, "timeout when waiting for the tests to complete, if 0 is specified, no timeout will be applied (default 0)")
-	cmd.Flags().BoolVar(&c.Wait, "wait", false, "waits until the tests are completed")
+	cmd.Flags().BoolVar(&c.NoWait, "no-wait", false, "do not wait until the tests are completed")
+
+	c.Labels = make(map[string]string)
+	cmd.Flags().Var(c.Labels, "set-label", "set a label in form key:value for all test executions in the run")
 }
 
 type TestGet struct {


### PR DESCRIPTION
This PR changes --wait to --no-wait for signadot test and adds a `--set-label` argument

