### PR TITLE
Test executions api refactoring

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,8 +15,8 @@ require (
 	github.com/nsf/jsondiff v0.0.0-20210926074059-1e845ec5d249
 	github.com/oklog/run v1.1.0
 	github.com/panta/machineid v1.0.2
-	github.com/signadot/go-sdk v0.3.8-0.20250401190938-c9abee021c5f
-	github.com/signadot/libconnect v0.1.1-0.20250210131700-02a354868e65
+	github.com/signadot/go-sdk v0.3.8-0.20250403191211-5a995e46b882
+	github.com/signadot/libconnect v0.1.1-0.20250403151636-040db1b80e12
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/viper v1.11.0
 	github.com/theckman/yacspin v0.13.12
@@ -34,6 +34,7 @@ require (
 	dario.cat/mergo v1.0.0 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/ProtonMail/go-crypto v1.1.5 // indirect
+	github.com/bwmarrin/snowflake v0.3.0 // indirect
 	github.com/cloudflare/circl v1.6.0 // indirect
 	github.com/cyphar/filepath-securejoin v0.4.1 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
@@ -111,7 +112,7 @@ require (
 	go.opentelemetry.io/otel/metric v1.35.0 // indirect
 	go.opentelemetry.io/otel/trace v1.35.0 // indirect
 	golang.org/x/crypto v0.35.0 // indirect
-	golang.org/x/oauth2 v0.26.0 // indirect
+	golang.org/x/oauth2 v0.27.0 // indirect
 	golang.org/x/sys v0.30.0 // indirect
 	golang.org/x/text v0.22.0 // indirect
 	golang.org/x/time v0.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -53,6 +53,8 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPd
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3dyBCFEj5IhUbnKptjxatkF07cF2ak3yi77so=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
+github.com/bwmarrin/snowflake v0.3.0 h1:xm67bEhkKh6ij1790JB83OujPR5CzNe8QuQqAgISZN0=
+github.com/bwmarrin/snowflake v0.3.0/go.mod h1:NdZxfVWX+oR6y2K0o6qAYv6gIOP9rjG0/E9WsDpxqwE=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
@@ -323,10 +325,10 @@ github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN3Uc8sB6B/s6Z4t2xvBgU1htSHuq8=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
-github.com/signadot/go-sdk v0.3.8-0.20250401190938-c9abee021c5f h1:o+fDco7C72B335zN7oQh3GITcIZGGLSaSgzLGmXFdF8=
-github.com/signadot/go-sdk v0.3.8-0.20250401190938-c9abee021c5f/go.mod h1:GQXaXWZAFo7cFs3azL/JtSiKel9n1tGKBsY8eLyWqcU=
-github.com/signadot/libconnect v0.1.1-0.20250210131700-02a354868e65 h1:pN3+srSYQ7CvMVLhLuCsBoKUKxQliTRmJ7U5KIM2lPY=
-github.com/signadot/libconnect v0.1.1-0.20250210131700-02a354868e65/go.mod h1:O32z0CKYCC94X+N+U0dECVo6o2gE7S1vfwO8fIe6a0o=
+github.com/signadot/go-sdk v0.3.8-0.20250403191211-5a995e46b882 h1:D1tZFMrsuxP0vsR0LxUSzSgwUoPW+C8PbzNar151fjY=
+github.com/signadot/go-sdk v0.3.8-0.20250403191211-5a995e46b882/go.mod h1:GQXaXWZAFo7cFs3azL/JtSiKel9n1tGKBsY8eLyWqcU=
+github.com/signadot/libconnect v0.1.1-0.20250403151636-040db1b80e12 h1:398UHgqXWwWKAmjmkEnpVpUC9jx+CDDpuKuai54imR8=
+github.com/signadot/libconnect v0.1.1-0.20250403151636-040db1b80e12/go.mod h1:rv9uifmo3n2g3TMEVRgThcrQyuNjGX4Hc08n/AWBK4g=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/skeema/knownhosts v1.3.1 h1:X2osQ+RAjK76shCbvhHHHVl3ZlgDm8apHEHFqRjnBY8=
 github.com/skeema/knownhosts v1.3.1/go.mod h1:r7KTdC8l4uxWRyK2TpQZ/1o5HaSzh06ePQNxPwTcfiY=
@@ -479,8 +481,8 @@ golang.org/x/oauth2 v0.0.0-20200902213428-5d25da1a8d43/go.mod h1:KelEdhl1UZF7XfJ
 golang.org/x/oauth2 v0.0.0-20201109201403-9fd604954f58/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20201208152858-08078c50e5b5/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20210218202405-ba52d332ba99/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
-golang.org/x/oauth2 v0.26.0 h1:afQXWNNaeC4nvZ0Ed9XvCCzXM6UHJG7iCg0W4fPqSBE=
-golang.org/x/oauth2 v0.26.0/go.mod h1:XYTD2NtWslqkgxebSiOHnXEap4TF09sJSc7H1sXbhtI=
+golang.org/x/oauth2 v0.27.0 h1:da9Vo7/tDv5RH/7nZDz1eMGS/q1Vv1N/7FCrBhI9I3M=
+golang.org/x/oauth2 v0.27.0/go.mod h1:onh5ek6nERTohokkhCD/y2cV4Do3fxFHFuAejCkRWT8=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/internal/command/test/cancel.go
+++ b/internal/command/test/cancel.go
@@ -16,7 +16,7 @@ func newCancel(tConfig *config.Test) *cobra.Command {
 		Test: tConfig,
 	}
 	cmd := &cobra.Command{
-		Use:   "cancel [<name> | --run-id <run-ID>]",
+		Use:   "cancel [<execution-ID> | --run-id <run-ID>]",
 		Short: "Cancel test executions",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return cancel(cmd.Context(), cfg, cmd.OutOrStdout(), cmd.ErrOrStderr(), args)
@@ -68,26 +68,26 @@ func cancelByRunID(ctx context.Context, cfg *config.TestCancel, runID string,
 	}
 
 	for _, tx := range txs {
-		err = cancelExecution(ctx, cfg, tx.Name, wOut)
+		err = cancelExecution(ctx, cfg, tx.ID, wOut)
 		if err != nil {
-			return fmt.Errorf("could not cancel test execution %q: %w", tx.Name, err)
+			return fmt.Errorf("could not cancel test execution %q: %w", tx.ID, err)
 		}
 	}
 	return nil
 }
 
-func cancelExecution(ctx context.Context, cfg *config.TestCancel, execName string,
+func cancelExecution(ctx context.Context, cfg *config.TestCancel, execID string,
 	wOut io.Writer) error {
 	params := test_executions.NewCancelTestExecutionParams().
 		WithContext(ctx).
 		WithOrgName(cfg.Org).
-		WithExecutionName(execName)
+		WithExecutionID(execID)
 	_, err := cfg.Client.TestExecutions.CancelTestExecution(params, nil)
 	if err != nil {
 		return err
 	}
 	if cfg.OutputFormat == config.OutputFormatDefault {
-		fmt.Fprintf(wOut, "Test execution %q canceled.\n", execName)
+		fmt.Fprintf(wOut, "Test execution %q canceled.\n", execID)
 	}
 	return nil
 }

--- a/internal/command/test/get.go
+++ b/internal/command/test/get.go
@@ -14,7 +14,7 @@ func newGet(tConfig *config.Test) *cobra.Command {
 		Test: tConfig,
 	}
 	cmd := &cobra.Command{
-		Use:   "get <name>",
+		Use:   "get <execution-ID>",
 		Short: "Get a test execution",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -29,10 +29,11 @@ func get(cfg *config.TestGet, wOut, wErr io.Writer, args []string) error {
 	if err := cfg.InitAPIConfig(); err != nil {
 		return err
 	}
-	execName := args[0]
+	execID := args[0]
 
-	params := test_executions.NewGetTestExecutionParams().WithOrgName(cfg.Org).
-		WithExecutionName(execName)
+	params := test_executions.NewGetTestExecutionParams().
+		WithOrgName(cfg.Org).
+		WithExecutionID(execID)
 	result, err := cfg.Client.TestExecutions.GetTestExecution(params, nil)
 	if err != nil {
 		return err

--- a/internal/command/test/print.go
+++ b/internal/command/test/print.go
@@ -27,13 +27,12 @@ func PrintTestExecution(oFmt config.OutputFormat, w io.Writer, tx *models.TestEx
 
 func printTestExecutionDetails(w io.Writer, tx *models.TestExecution) error {
 	tw := tabwriter.NewWriter(w, 0, 0, 3, ' ', 0)
-	fmt.Fprintf(tw, "Name:\t%s\n", tx.Name)
+	fmt.Fprintf(tw, "ID:\t%s\n", tx.ID)
 
-	if tx.Spec.EmbeddedSpec != nil {
-		spec := tx.Spec.EmbeddedSpec
+	if tx.Spec.External != nil {
+		spec := tx.Spec.External
 		// this is an external test
 		fmt.Fprint(tw, "Source:\texternal\n")
-		fmt.Fprintf(tw, "RunID:\t%s\n", spec.RunID)
 		fmt.Fprintf(tw, "TestName:\t%s\n", spec.TestName)
 		if spec.Repo != "" {
 			// this is a git test
@@ -42,13 +41,11 @@ func printTestExecutionDetails(w io.Writer, tx *models.TestExecution) error {
 			fmt.Fprintf(tw, "Branch:\t%s\n", spec.Branch)
 			fmt.Fprintf(tw, "CommitSHA:\t%s\n", spec.CommitSHA)
 		}
-		if len(spec.Labels) > 0 {
-			fmt.Fprintf(tw, "Labels:\t%s\n", getLabels(spec.Labels))
-		}
-	} else {
+	} else if tx.Spec.Hosted != nil {
+		spec := tx.Spec.Hosted
 		// this is a hosted test
 		fmt.Fprint(tw, "Source:\thosted\n")
-		fmt.Fprintf(tw, "TestName:\t%s\n", tx.Spec.Test)
+		fmt.Fprintf(tw, "TestName:\t%s\n", spec.TestName)
 		if tx.Status.TriggeredBy != nil && tx.Status.TriggeredBy.Sandbox != "" {
 			fmt.Fprintf(tw, "TriggeredBy:\t%s\n", tx.Status.TriggeredBy.Sandbox)
 		} else {
@@ -56,8 +53,13 @@ func printTestExecutionDetails(w io.Writer, tx *models.TestExecution) error {
 		}
 	}
 
+	if len(tx.Spec.Labels) > 0 {
+		fmt.Fprintf(tw, "Labels:\t%s\n", getLabels(tx.Spec.Labels))
+	}
+
 	if tx.Spec.ExecutionContext != nil {
 		ec := tx.Spec.ExecutionContext
+		fmt.Fprintf(tw, "RunID:\t%s\n", ec.RunID)
 		fmt.Fprintf(tw, "Cluster:\t%s\n", ec.Cluster)
 		if ec.Routing != nil {
 			if ec.Routing.Sandbox != "" {
@@ -114,7 +116,7 @@ func getResults(tx *models.TestExecution) string {
 }
 
 type testExecRow struct {
-	Name      string `sdtab:"NAME"`
+	ID        string `sdtab:"ID"`
 	Source    string `sdtab:"SOURCE"`
 	Phase     string `sdtab:"PHASE"`
 	CreatedAt string `sdtab:"CREATED"`
@@ -126,11 +128,11 @@ func printTestExecutionsTable(w io.Writer, txs []*models.TestexecutionsQueryResu
 	for _, item := range txs {
 		tx := item.Execution
 		source := "hosted"
-		if tx.Spec != nil && tx.Spec.EmbeddedSpec != nil {
+		if tx.Spec != nil && tx.Spec.External != nil {
 			source = "external"
 		}
 		tab.AddRow(testExecRow{
-			Name:      tx.Name,
+			ID:        tx.ID,
 			Source:    source,
 			CreatedAt: tx.CreatedAt,
 			Phase:     tx.Status.Phase,

--- a/internal/command/test/run_output.go
+++ b/internal/command/test/run_output.go
@@ -108,7 +108,7 @@ func (o *defaultRunOutput) renderTestXsTable(txs []*models.TestExecution, runnin
 
 		// add some padding to completely overwrite lines
 		padding := "      "
-		fmt.Fprintf(o.wOut, "%s\t%s\t[%s]%s\n", icon, tx.Spec.EmbeddedSpec.TestName, statusText, padding)
+		fmt.Fprintf(o.wOut, "%s\t%s\t[%s]%s\n", icon, tx.Spec.External.TestName, statusText, padding)
 	}
 }
 

--- a/internal/repoconfig/config.go
+++ b/internal/repoconfig/config.go
@@ -2,7 +2,6 @@ package repoconfig
 
 import (
 	"fmt"
-	"math/rand"
 	"os"
 	"path/filepath"
 
@@ -19,19 +18,6 @@ type TestFile struct {
 	Name   string            // Test name
 	Path   string            // Full path relative to base directory
 	Labels map[string]string // Labels from all parent directories
-}
-
-// GenerateRunID creates a random alphanumeric string for the run
-func GenerateRunID() string {
-	const charset = "abcdefghijklmnopqrstuvwxyz0123456789"
-	const length = 8
-
-	// Generate random string
-	b := make([]byte, length)
-	for i := range b {
-		b[i] = charset[rand.Intn(len(charset))]
-	}
-	return string(b)
 }
 
 // LoadConfig reads the .signadot/config.yaml file from the git repository root

--- a/local-sb.yaml
+++ b/local-sb.yaml
@@ -9,7 +9,7 @@ spec:
   - name: "local-route"
     from:
       kind: Deployment
-      namespace: hotrod
+      namespace: hotrod-devmesh
       name: route
     mappings:
     - port: 8083
@@ -17,7 +17,7 @@ spec:
   defaultRouteGroup:
     endpoints: 
     - name: route-endpoint
-      target: http://route.hotrod.svc:8083
+      target: http://route.hotrod-devmesh.svc:8083
     - name: frontend-endpoint
-      target: http://frontend.hotrod.svc:8080
+      target: http://frontend.hotrod-devmesh.svc:8080
 


### PR DESCRIPTION
Depends on:
- https://github.com/signadot/go-sdk/pull/61
- https://github.com/signadot/libconnect/pull/93

This integrates against the new test executions API.