### PR TITLE
truncate the output of wait

### DIFF
--- a/internal/command/smarttest/printers.go
+++ b/internal/command/smarttest/printers.go
@@ -149,7 +149,7 @@ func printTestExecutionsTable(w io.Writer, txs []*models.TestexecutionsQueryResu
 		tab.AddRow(testExecRow{
 			ID:          tx.ID,
 			Source:      source,
-			TestName:    truncateTestName(testName),
+			TestName:    truncateTestName(testName, 48),
 			Environment: environment,
 			CreatedAt:   createdAt,
 			Duration:    duration,
@@ -159,9 +159,8 @@ func printTestExecutionsTable(w io.Writer, txs []*models.TestexecutionsQueryResu
 	return tab.Flush()
 }
 
-func truncateTestName(tn string) string {
-	N := 48
-	if len(tn) > N {
+func truncateTestName(tn string, N int) string {
+	if len(tn) > N && N > 3 {
 		start := len(tn) - (N - 3)
 		return "..." + tn[start:]
 	}

--- a/internal/command/smarttest/run_output.go
+++ b/internal/command/smarttest/run_output.go
@@ -107,7 +107,7 @@ func (o *defaultRunOutput) renderTestXsTable(txs []*models.TestExecution, runnin
 			icon = "⚪"
 			statusText = tx.Status.Phase
 		}
-		fmt.Fprintf(tw, "%s\t%s\t[ID: %s, STATUS: %s]\n", icon, tx.Spec.External.TestName,
+		fmt.Fprintf(tw, "%s\t%s\t[ID: %s, STATUS: %s]\n", icon, truncateTestName(tx.Spec.External.TestName, 48),
 			tx.ID, statusText)
 	}
 	tw.Flush()


### PR DESCRIPTION
without this, there is greater risk of going up the wrong number of lines to overwrite each entry with yacspin