### PR TITLE
Fix bearer-token auth in controlplaneproxy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/oklog/run v1.1.0
 	github.com/panta/machineid v1.0.2
 	github.com/signadot/go-sdk v0.3.8-0.20250502141929-71adbfb62bd0
-	github.com/signadot/libconnect v0.1.1-0.20250505131244-cea1c0fdbfde
+	github.com/signadot/libconnect v0.1.1-0.20250505142819-1d266e77df07
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/viper v1.11.0
 	github.com/theckman/yacspin v0.13.12

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/oklog/run v1.1.0
 	github.com/panta/machineid v1.0.2
 	github.com/signadot/go-sdk v0.3.8-0.20250502141929-71adbfb62bd0
-	github.com/signadot/libconnect v0.1.1-0.20250505142819-1d266e77df07
+	github.com/signadot/libconnect v0.1.1-0.20250505143054-fbbea25d0081
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/viper v1.11.0
 	github.com/theckman/yacspin v0.13.12

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/oklog/run v1.1.0
 	github.com/panta/machineid v1.0.2
 	github.com/signadot/go-sdk v0.3.8-0.20250502141929-71adbfb62bd0
-	github.com/signadot/libconnect v0.1.1-0.20250502144057-7eab70077f7f
+	github.com/signadot/libconnect v0.1.1-0.20250505131244-cea1c0fdbfde
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/viper v1.11.0
 	github.com/theckman/yacspin v0.13.12

--- a/go.sum
+++ b/go.sum
@@ -333,8 +333,8 @@ github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
 github.com/signadot/go-sdk v0.3.8-0.20250502141929-71adbfb62bd0 h1:ujylkC2g7u05OYm91oa+ovPK8nmjQq7PO39PNexNP3o=
 github.com/signadot/go-sdk v0.3.8-0.20250502141929-71adbfb62bd0/go.mod h1:pnXR9BhGedBWjtAZGwGGY94sMgh6VuAbP/4vq4Qw1Fg=
-github.com/signadot/libconnect v0.1.1-0.20250502144057-7eab70077f7f h1:V4kQgQsEJhDfh1LYa2LW2SoJLMaoCP2IYnCpIcMuQXc=
-github.com/signadot/libconnect v0.1.1-0.20250502144057-7eab70077f7f/go.mod h1:MWfhryOARFnhDnmYGcTmmu+kHJbE6z0dDgKQpxOKVLQ=
+github.com/signadot/libconnect v0.1.1-0.20250505131244-cea1c0fdbfde h1:CI1CudT/CGQBz6vC9xpNBLs+v2R7n5rcpNhNLAGVGmg=
+github.com/signadot/libconnect v0.1.1-0.20250505131244-cea1c0fdbfde/go.mod h1:MWfhryOARFnhDnmYGcTmmu+kHJbE6z0dDgKQpxOKVLQ=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/skeema/knownhosts v1.3.1 h1:X2osQ+RAjK76shCbvhHHHVl3ZlgDm8apHEHFqRjnBY8=
 github.com/skeema/knownhosts v1.3.1/go.mod h1:r7KTdC8l4uxWRyK2TpQZ/1o5HaSzh06ePQNxPwTcfiY=

--- a/go.sum
+++ b/go.sum
@@ -333,8 +333,8 @@ github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
 github.com/signadot/go-sdk v0.3.8-0.20250502141929-71adbfb62bd0 h1:ujylkC2g7u05OYm91oa+ovPK8nmjQq7PO39PNexNP3o=
 github.com/signadot/go-sdk v0.3.8-0.20250502141929-71adbfb62bd0/go.mod h1:pnXR9BhGedBWjtAZGwGGY94sMgh6VuAbP/4vq4Qw1Fg=
-github.com/signadot/libconnect v0.1.1-0.20250505142819-1d266e77df07 h1:iltwLW9zWLIe5ZaJD6TBYoEWNOPtcJBD1z0w3rpVXco=
-github.com/signadot/libconnect v0.1.1-0.20250505142819-1d266e77df07/go.mod h1:MWfhryOARFnhDnmYGcTmmu+kHJbE6z0dDgKQpxOKVLQ=
+github.com/signadot/libconnect v0.1.1-0.20250505143054-fbbea25d0081 h1:sGiEMUNzm4ZsjVtBJQGkTsnVYJSTN/VW0V5oVAMhmxY=
+github.com/signadot/libconnect v0.1.1-0.20250505143054-fbbea25d0081/go.mod h1:MWfhryOARFnhDnmYGcTmmu+kHJbE6z0dDgKQpxOKVLQ=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/skeema/knownhosts v1.3.1 h1:X2osQ+RAjK76shCbvhHHHVl3ZlgDm8apHEHFqRjnBY8=
 github.com/skeema/knownhosts v1.3.1/go.mod h1:r7KTdC8l4uxWRyK2TpQZ/1o5HaSzh06ePQNxPwTcfiY=

--- a/go.sum
+++ b/go.sum
@@ -333,8 +333,8 @@ github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
 github.com/signadot/go-sdk v0.3.8-0.20250502141929-71adbfb62bd0 h1:ujylkC2g7u05OYm91oa+ovPK8nmjQq7PO39PNexNP3o=
 github.com/signadot/go-sdk v0.3.8-0.20250502141929-71adbfb62bd0/go.mod h1:pnXR9BhGedBWjtAZGwGGY94sMgh6VuAbP/4vq4Qw1Fg=
-github.com/signadot/libconnect v0.1.1-0.20250505131244-cea1c0fdbfde h1:CI1CudT/CGQBz6vC9xpNBLs+v2R7n5rcpNhNLAGVGmg=
-github.com/signadot/libconnect v0.1.1-0.20250505131244-cea1c0fdbfde/go.mod h1:MWfhryOARFnhDnmYGcTmmu+kHJbE6z0dDgKQpxOKVLQ=
+github.com/signadot/libconnect v0.1.1-0.20250505142819-1d266e77df07 h1:iltwLW9zWLIe5ZaJD6TBYoEWNOPtcJBD1z0w3rpVXco=
+github.com/signadot/libconnect v0.1.1-0.20250505142819-1d266e77df07/go.mod h1:MWfhryOARFnhDnmYGcTmmu+kHJbE6z0dDgKQpxOKVLQ=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/skeema/knownhosts v1.3.1 h1:X2osQ+RAjK76shCbvhHHHVl3ZlgDm8apHEHFqRjnBY8=
 github.com/skeema/knownhosts v1.3.1/go.mod h1:r7KTdC8l4uxWRyK2TpQZ/1o5HaSzh06ePQNxPwTcfiY=

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -1,8 +1,11 @@
 package auth
 
 import (
+	"net/http"
 	"time"
 
+	"github.com/go-openapi/runtime"
+	"github.com/signadot/go-sdk/transport"
 	"github.com/spf13/viper"
 )
 
@@ -64,4 +67,22 @@ func loadAuth() (*ResolvedAuth, error) {
 		Source: KeyringAuthSource,
 		Auth:   *auth,
 	}, nil
+}
+
+func GetHeaders() (http.Header, error) {
+	authInfo, err := ResolveAuth()
+	if err != nil {
+		return nil, err
+	}
+
+	headers := http.Header{}
+	if authInfo == nil {
+		return headers, nil
+	}
+	if authInfo.APIKey != "" {
+		headers.Set(transport.APIKeyHeader, authInfo.APIKey)
+	} else if authInfo.BearerToken != "" {
+		headers.Set(runtime.HeaderAuthorization, "Bearer "+authInfo.BearerToken)
+	}
+	return headers, nil
 }

--- a/internal/command/local/proxy.go
+++ b/internal/command/local/proxy.go
@@ -93,13 +93,13 @@ func runProxy(cmd *cobra.Command, out io.Writer, cfg *config.LocalProxy, args []
 		pm := &cfg.ProxyMappings[i]
 
 		ctlPlaneProxy, err := controlplaneproxy.NewProxy(&controlplaneproxy.Config{
-			Log:        log,
-			ProxyURL:   cfg.ProxyURL,
-			TargetURL:  pm.GetTarget(),
-			Cluster:    cluster,
-			RoutingKey: routingKey,
-			BindAddr:   pm.BindAddr,
-			GetHeaders: auth.GetHeaders,
+			Log:              log,
+			ProxyURL:         cfg.ProxyURL,
+			TargetURL:        pm.GetTarget(),
+			Cluster:          cluster,
+			RoutingKey:       routingKey,
+			BindAddr:         pm.BindAddr,
+			GetInjectHeaders: auth.GetHeaders,
 		})
 		if err != nil {
 			return err

--- a/internal/command/local/proxy.go
+++ b/internal/command/local/proxy.go
@@ -9,6 +9,7 @@ import (
 	_ "net/http/pprof"
 
 	"github.com/oklog/run"
+	"github.com/signadot/cli/internal/auth"
 	"github.com/signadot/cli/internal/config"
 	clusters "github.com/signadot/go-sdk/client/cluster"
 	routegroups "github.com/signadot/go-sdk/client/route_groups"
@@ -98,7 +99,8 @@ func runProxy(cmd *cobra.Command, out io.Writer, cfg *config.LocalProxy, args []
 			Cluster:    cluster,
 			RoutingKey: routingKey,
 			BindAddr:   pm.BindAddr,
-		}, cfg.GetAPIKey())
+			GetHeaders: auth.GetHeaders,
+		})
 		if err != nil {
 			return err
 		}

--- a/internal/command/local/proxy.go
+++ b/internal/command/local/proxy.go
@@ -24,7 +24,7 @@ func newProxy(localConfig *config.Local) *cobra.Command {
 	}
 
 	cmd := &cobra.Command{
-		Use:   "proxy [--sandbox SANDBOX|--routegroup ROUTEGROUP|--cluster CLUSTER] --map <target-protocol>://<target-addr>|<bind-addr> [--map <target-protocol>://<target-addr>@<bind-addr>]",
+		Use:   "proxy [--sandbox SANDBOX|--routegroup ROUTEGROUP|--cluster CLUSTER] --map <target-protocol>://<target-addr>@<bind-addr> [--map <target-protocol>://<target-addr>@<bind-addr>]",
 		Short: "Proxy connections based on the specified mappings",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runProxy(cmd, cmd.OutOrStdout(), cfg, args)

--- a/internal/locald/sandboxmanager/sandbox_manager.go
+++ b/internal/locald/sandboxmanager/sandbox_manager.go
@@ -123,12 +123,12 @@ func (m *sandboxManager) Run(ctx context.Context) error {
 
 		// Start a control-plane proxy
 		ctlPlaneProxy, err := controlplaneproxy.NewProxy(&controlplaneproxy.Config{
-			Log:        m.log,
-			ProxyURL:   m.ciConfig.ProxyURL,
-			TargetURL:  "tcp://tunnel-proxy.signadot.svc:1080",
-			Cluster:    m.connConfig.Cluster,
-			BindAddr:   ":0",
-			GetHeaders: getHeaders,
+			Log:              m.log,
+			ProxyURL:         m.ciConfig.ProxyURL,
+			TargetURL:        "tcp://tunnel-proxy.signadot.svc:1080",
+			Cluster:          m.connConfig.Cluster,
+			BindAddr:         ":0",
+			GetInjectHeaders: getHeaders,
 		})
 		if err != nil {
 			return err


### PR DESCRIPTION
Depends on https://github.com/signadot/signadot/pull/5754, https://github.com/signadot/libconnect/pull/98.

Fix `bearer-token` auth when using `controlplaneproxy`.