### PR TITLE
Refactor of auth/device/token API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/nsf/jsondiff v0.0.0-20210926074059-1e845ec5d249
 	github.com/oklog/run v1.1.0
 	github.com/panta/machineid v1.0.2
-	github.com/signadot/go-sdk v0.3.8-0.20250508133241-e49610532d0f
+	github.com/signadot/go-sdk v0.3.8-0.20250512165812-53eb89975b2a
 	github.com/signadot/libconnect v0.1.1-0.20250505143054-fbbea25d0081
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/viper v1.11.0

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/nsf/jsondiff v0.0.0-20210926074059-1e845ec5d249
 	github.com/oklog/run v1.1.0
 	github.com/panta/machineid v1.0.2
-	github.com/signadot/go-sdk v0.3.8-0.20250502141929-71adbfb62bd0
+	github.com/signadot/go-sdk v0.3.8-0.20250508133241-e49610532d0f
 	github.com/signadot/libconnect v0.1.1-0.20250505143054-fbbea25d0081
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/viper v1.11.0
@@ -62,7 +62,7 @@ require (
 	github.com/x448/float16 v0.8.4 // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	golang.org/x/sync v0.13.0 // indirect
+	golang.org/x/sync v0.14.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250414145226-207652e42e2e // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -331,8 +331,8 @@ github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN3Uc8sB6B/s6Z4t2xvBgU1htSHuq8=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
-github.com/signadot/go-sdk v0.3.8-0.20250508133241-e49610532d0f h1:zJsC9uV0qOMfwx4dZzrvL6zm7L4izrJrPrKcTYDy4/s=
-github.com/signadot/go-sdk v0.3.8-0.20250508133241-e49610532d0f/go.mod h1:mK44llfPHwm02Fz3vFKPzqgP/zQftUgndGayY4WIV5w=
+github.com/signadot/go-sdk v0.3.8-0.20250512165812-53eb89975b2a h1:bJqx8yL+vgJciabu6x2uU9yVtosGtCTzztiH9i4hTo8=
+github.com/signadot/go-sdk v0.3.8-0.20250512165812-53eb89975b2a/go.mod h1:mK44llfPHwm02Fz3vFKPzqgP/zQftUgndGayY4WIV5w=
 github.com/signadot/libconnect v0.1.1-0.20250505143054-fbbea25d0081 h1:sGiEMUNzm4ZsjVtBJQGkTsnVYJSTN/VW0V5oVAMhmxY=
 github.com/signadot/libconnect v0.1.1-0.20250505143054-fbbea25d0081/go.mod h1:MWfhryOARFnhDnmYGcTmmu+kHJbE6z0dDgKQpxOKVLQ=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=

--- a/go.sum
+++ b/go.sum
@@ -331,8 +331,8 @@ github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN3Uc8sB6B/s6Z4t2xvBgU1htSHuq8=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
-github.com/signadot/go-sdk v0.3.8-0.20250502141929-71adbfb62bd0 h1:ujylkC2g7u05OYm91oa+ovPK8nmjQq7PO39PNexNP3o=
-github.com/signadot/go-sdk v0.3.8-0.20250502141929-71adbfb62bd0/go.mod h1:pnXR9BhGedBWjtAZGwGGY94sMgh6VuAbP/4vq4Qw1Fg=
+github.com/signadot/go-sdk v0.3.8-0.20250508133241-e49610532d0f h1:zJsC9uV0qOMfwx4dZzrvL6zm7L4izrJrPrKcTYDy4/s=
+github.com/signadot/go-sdk v0.3.8-0.20250508133241-e49610532d0f/go.mod h1:mK44llfPHwm02Fz3vFKPzqgP/zQftUgndGayY4WIV5w=
 github.com/signadot/libconnect v0.1.1-0.20250505143054-fbbea25d0081 h1:sGiEMUNzm4ZsjVtBJQGkTsnVYJSTN/VW0V5oVAMhmxY=
 github.com/signadot/libconnect v0.1.1-0.20250505143054-fbbea25d0081/go.mod h1:MWfhryOARFnhDnmYGcTmmu+kHJbE6z0dDgKQpxOKVLQ=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
@@ -504,8 +504,8 @@ golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.13.0 h1:AauUjRAJ9OSnvULf/ARrrVywoJDy0YS2AwQ98I37610=
-golang.org/x/sync v0.13.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
+golang.org/x/sync v0.14.0 h1:woo0S4Yywslg6hp4eUFjTVOyKt0RookbpAHG4c1HmhQ=
+golang.org/x/sync v0.14.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190312061237-fead79001313/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/internal/config/api.go
+++ b/internal/config/api.go
@@ -116,6 +116,12 @@ func (a *API) InitAPIConfigWithApiKey(apiKey string) error {
 	return a.InitAPITransport()
 }
 
+func (a *API) InitAPIConfigWithBearerToken(bearerToken string) error {
+	a.BearerToken = bearerToken
+	a.basicInit()
+	return a.InitAPITransport()
+}
+
 func (a *API) GetBaseTransport() *transport.APIConfig {
 	cfg := &transport.APIConfig{
 		APIURL:          a.APIURL,


### PR DESCRIPTION
Depends on:
- https://github.com/signadot/go-sdk/pull/65
- https://github.com/signadot/signadot/pull/5774

This PR uses the `/api/v2/orgs` endpoint to resolve Orgs (instead of getting it from `/auth/device/token`).