### PR TITLE
add label selection and local listing to `signadot st`

### DIFF
--- a/internal/command/smarttest/command.go
+++ b/internal/command/smarttest/command.go
@@ -13,10 +13,12 @@ func New(api *config.API) *cobra.Command {
 		Aliases: []string{"st"},
 	}
 
+	list := newList(cfg)
 	run := newRun(cfg)
 	exec := newExecution(cfg)
 
 	// Subcommands
+	cmd.AddCommand(list)
 	cmd.AddCommand(run)
 	cmd.AddCommand(exec)
 	return cmd

--- a/internal/command/smarttest/execution.go
+++ b/internal/command/smarttest/execution.go
@@ -15,7 +15,7 @@ func newExecution(tConfig *config.SmartTest) *cobra.Command {
 		Short:   "Work with smart test executions",
 	}
 	get := newGet(cfg)
-	list := newList(cfg)
+	list := newXList(cfg)
 	cancel := newCancel(cfg)
 	cmd.AddCommand(get)
 	cmd.AddCommand(list)

--- a/internal/command/smarttest/execution_list.go
+++ b/internal/command/smarttest/execution_list.go
@@ -11,7 +11,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newList(tConfig *config.SmartTestExec) *cobra.Command {
+func newXList(tConfig *config.SmartTestExec) *cobra.Command {
 	cfg := &config.SmartTestExecList{
 		SmartTestExec: tConfig,
 	}
@@ -19,14 +19,14 @@ func newList(tConfig *config.SmartTestExec) *cobra.Command {
 		Use:   "list [filter-opts]",
 		Short: "List test executions",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return list(cfg, cmd.OutOrStdout(), cmd.ErrOrStderr(), args)
+			return xList(cfg, cmd.OutOrStdout(), cmd.ErrOrStderr(), args)
 		},
 	}
 	cfg.AddFlags(cmd)
 	return cmd
 }
 
-func list(cfg *config.SmartTestExecList, wOut, wErr io.Writer, args []string) error {
+func xList(cfg *config.SmartTestExecList, wOut, wErr io.Writer, args []string) error {
 	if err := cfg.InitAPIConfig(); err != nil {
 		return err
 	}

--- a/internal/command/smarttest/list.go
+++ b/internal/command/smarttest/list.go
@@ -1,0 +1,123 @@
+package smarttest
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+
+	"github.com/signadot/cli/internal/config"
+	"github.com/signadot/cli/internal/print"
+	"github.com/signadot/cli/internal/repoconfig"
+	"github.com/spf13/cobra"
+)
+
+func newList(tConfig *config.SmartTest) *cobra.Command {
+	cfg := &config.SmartTestList{
+		SmartTest: tConfig,
+	}
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List tests",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return list(cmd.Context(), cfg, cmd.OutOrStdout(), cmd.ErrOrStderr(), args)
+		},
+	}
+	cfg.AddFlags(cmd)
+	return cmd
+}
+
+func list(ctx context.Context, cfg *config.SmartTestList, wOut, wErr io.Writer,
+	args []string) error {
+	if err := cfg.InitAPIConfig(); err != nil {
+		return err
+	}
+	if err := validateList(cfg); err != nil {
+		return err
+	}
+	testFiles, _, err := testFilesAndRepo(cfg)
+	if err != nil {
+		return err
+	}
+	// render the structured output
+	return listOutput(cfg, wOut, testFiles)
+}
+
+func testFilesAndRepo(cfg *config.SmartTestList) ([]repoconfig.TestFile, *repoconfig.GitRepo, error) {
+	if cfg.File == "-" {
+		host, err := os.Hostname()
+		if err != nil {
+			host = "unknown"
+		}
+		pid := strconv.Itoa(os.Getpid())
+		return []repoconfig.TestFile{
+			{
+				Name:   host + "-" + "stdin-" + pid,
+				Reader: os.Stdin,
+			},
+		}, nil, nil
+	}
+	// create a test finder
+	// NOTE: at most one of cfg.{Dir,File} is non-empty
+	tf, err := repoconfig.NewTestFinder(cfg.Directory+cfg.File, cfg.FilterLabels, cfg.WithoutLabels)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// find tests
+	testFiles, err := tf.FindTestFiles()
+	if err != nil {
+		return nil, nil, fmt.Errorf("error finding test files: %w", err)
+	}
+	if len(testFiles) == 0 {
+		return nil, nil, errors.New("could not find any test")
+	}
+	return testFiles, tf.GetGitRepo(), nil
+}
+
+func validateList(cfg *config.SmartTestList) error {
+	if cfg.Directory != "" && cfg.File != "" {
+		return fmt.Errorf("cannot specify both directory and file")
+	}
+	if cfg.Directory != "" {
+		st, err := os.Stat(cfg.Directory)
+		if err != nil {
+			return fmt.Errorf("unable to stat input directory: %w", err)
+		}
+		if !st.IsDir() {
+			return fmt.Errorf("%q is not a directory", cfg.Directory)
+		}
+	}
+	if cfg.File != "" && cfg.File != "-" {
+		st, err := os.Stat(cfg.File)
+		if err != nil {
+			return fmt.Errorf("unable to stat input file: %w", err)
+		}
+		if st.IsDir() {
+			return fmt.Errorf("%q is not a file", cfg.File)
+		}
+	}
+
+	return nil
+}
+
+func listOutput(cfg *config.SmartTestList, w io.Writer, tfs []repoconfig.TestFile) error {
+	switch cfg.OutputFormat {
+	case config.OutputFormatDefault:
+		for i := range tfs {
+			tf := &tfs[i]
+			if _, err := fmt.Fprintf(w, tf.Name+"\n"); err != nil {
+				return err
+			}
+		}
+		return nil
+	case config.OutputFormatYAML:
+		return print.RawYAML(w, tfs)
+	case config.OutputFormatJSON:
+		return print.RawJSON(w, tfs)
+	default:
+		return fmt.Errorf("unsupported output format: %q", cfg.OutputFormat)
+	}
+}

--- a/internal/command/smarttest/list.go
+++ b/internal/command/smarttest/list.go
@@ -20,7 +20,7 @@ func newList(tConfig *config.SmartTest) *cobra.Command {
 	}
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: "List tests",
+		Short: "List local tests",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return list(cmd.Context(), cfg, cmd.OutOrStdout(), cmd.ErrOrStderr(), args)
 		},

--- a/internal/config/smarttest.go
+++ b/internal/config/smarttest.go
@@ -15,12 +15,28 @@ type SmartTest struct {
 	*API
 }
 
+type SmartTestList struct {
+	*SmartTest
+	Directory     string
+	File          string
+	FilterLabels  TestExecLabels
+	WithoutLabels TestExecLabels
+}
+
+func (c *SmartTestList) AddFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(&c.Directory, "directory", "d", "", "base directory for finding tests")
+	cmd.Flags().StringVarP(&c.File, "file", "f", "", "smart test file to run")
+	c.FilterLabels = make(map[string]string)
+	cmd.Flags().Var(&c.FilterLabels, "with-label", "only run tests with specified label in the form key=value (can be specified multiple times, value is a glob)")
+	c.WithoutLabels = make(map[string]string)
+	cmd.Flags().Var(&c.WithoutLabels, "without-label", "only run tests without specified label in the form key=value (can be specified multiple times, value is a glob)")
+}
+
 // SmartTestRun represents the configuration for running a test
 type SmartTestRun struct {
-	*SmartTest
-	Directory  string
-	File       string
-	Labels     TestExecLabels
+	*SmartTestList
+	AddLabels TestExecLabels
+
 	Cluster    string
 	Sandbox    string
 	RouteGroup string
@@ -73,8 +89,7 @@ func (tl TestExecLabels) ToQueryFilter() []string {
 
 // AddFlags adds the flags for the test run command
 func (c *SmartTestRun) AddFlags(cmd *cobra.Command) {
-	cmd.Flags().StringVarP(&c.Directory, "directory", "d", "", "base directory for finding tests")
-	cmd.Flags().StringVarP(&c.File, "file", "f", "", "smart test file to run")
+	c.SmartTestList.AddFlags(cmd)
 	cmd.Flags().StringVar(&c.Cluster, "cluster", "", "cluster where to run tests")
 	cmd.Flags().StringVar(&c.Sandbox, "sandbox", "", "sandbox where to run tests")
 	cmd.Flags().StringVar(&c.RouteGroup, "route-group", "", "route group where to run tests")
@@ -82,8 +97,8 @@ func (c *SmartTestRun) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().DurationVar(&c.Timeout, "timeout", 0, "timeout when waiting for the tests to complete, if 0 is specified, no timeout will be applied (default 0)")
 	cmd.Flags().BoolVar(&c.NoWait, "no-wait", false, "do not wait until the tests are completed")
 
-	c.Labels = make(map[string]string)
-	cmd.Flags().Var(&c.Labels, "set-label", "set a label in form key=value for all test executions in the run (can be specified multiple times)")
+	c.AddLabels = make(map[string]string)
+	cmd.Flags().Var(&c.AddLabels, "set-label", "set a label in form key=value for all test executions in the run (can be specified multiple times)")
 }
 
 type SmartTestExec struct {

--- a/internal/config/smarttest.go
+++ b/internal/config/smarttest.go
@@ -27,9 +27,9 @@ func (c *SmartTestList) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&c.Directory, "directory", "d", "", "base directory for finding tests")
 	cmd.Flags().StringVarP(&c.File, "file", "f", "", "smart test file to run")
 	c.FilterLabels = make(map[string]string)
-	cmd.Flags().Var(&c.FilterLabels, "with-label", "only run tests with specified label in the form key=value (can be specified multiple times, value is a glob)")
+	cmd.Flags().Var(&c.FilterLabels, "with-label", "select tests with specified label in the form key=value (can be specified multiple times, value is a glob)")
 	c.WithoutLabels = make(map[string]string)
-	cmd.Flags().Var(&c.WithoutLabels, "without-label", "only run tests without specified label in the form key=value (can be specified multiple times, value is a glob)")
+	cmd.Flags().Var(&c.WithoutLabels, "without-label", "select tests not matching the specified label in the form key=value (can be specified multiple times, value is a glob)")
 }
 
 // SmartTestRun represents the configuration for running a test

--- a/internal/repoconfig/config.go
+++ b/internal/repoconfig/config.go
@@ -16,10 +16,10 @@ type Config struct {
 
 // TestFile represents a test file found in the tests directory
 type TestFile struct {
-	Name   string            // Test name
-	Path   string            // Full path relative to base directory
-	Reader io.Reader         // if Path is empty, may be a Reader
-	Labels map[string]string // Labels from all parent directories
+	Name   string            `json:"name"`   // Test name
+	Path   string            `json:"path"`   // Full path relative to base directory
+	Reader io.Reader         `json:"-"`      // if Path is empty, may be a Reader
+	Labels map[string]string `json:"labels"` // Labels from all parent directories
 }
 
 // LoadConfig reads the .signadot/config.yaml file from the git repository root

--- a/internal/repoconfig/finder.go
+++ b/internal/repoconfig/finder.go
@@ -13,11 +13,11 @@ type TestFinder struct {
 	basePath string
 
 	dirLabelsCache LabelsCache
-	filterLabels   map[string]string
+	withLabels     map[string]string
 	withoutLabels  map[string]string
 }
 
-func NewTestFinder(inputPath string, filterLabels, withoutLabels map[string]string) (*TestFinder, error) {
+func NewTestFinder(inputPath string, withLabels, withoutLabels map[string]string) (*TestFinder, error) {
 	var tf *TestFinder
 
 	if inputPath != "" {
@@ -50,7 +50,7 @@ func NewTestFinder(inputPath string, filterLabels, withoutLabels map[string]stri
 			},
 			repo:          gitRepo,
 			basePath:      basePath,
-			filterLabels:  filterLabels,
+			withLabels:    withLabels,
 			withoutLabels: withoutLabels,
 		}
 	} else {
@@ -78,7 +78,7 @@ func NewTestFinder(inputPath string, filterLabels, withoutLabels map[string]stri
 			cfg:           repoConf,
 			repo:          gitRepo,
 			basePath:      gitRepo.Path,
-			filterLabels:  filterLabels,
+			withLabels:    withLabels,
 			withoutLabels: withoutLabels,
 		}
 	}
@@ -129,7 +129,7 @@ func (tf *TestFinder) FindTestFiles() ([]TestFile, error) {
 
 	var allTestFiles []TestFile
 	for _, tFile := range testFileMap {
-		allMatch, err := allLabelsMatch(tf.filterLabels, tFile.Labels)
+		allMatch, err := allLabelsMatch(tf.withLabels, tFile.Labels)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This PR adds the ability to filter the local tests by label by

1. Adding a new subcommand `signadot st list` which lists test files; and
2. Adding all the flags of `signadot st list` to `signadot st run`, so that the selected test files will be run


```
25-05-12 scott@air cli % ./signadot st -h
Signadot smart tests

Usage:
  signadot smart-test [command]

Aliases:
  smart-test, st

Available Commands:
  execution   Work with smart test executions
  list        List local tests
  run         Run tests

Flags:
  -h, --help   help for smart-test

Global Flags:
      --config string   config file (default is $HOME/.signadot/config.yaml)
      --debug           enable debug output
  -o, --output string   output format (json|yaml)

Use "signadot smart-test [command] --help" for more information about a command.
```

```
25-05-12 scott@air cli % ./signadot st list -h
List local tests

Usage:
  signadot smart-test list [flags]

Flags:
  -d, --directory string       base directory for finding tests
  -f, --file string            smart test file to run
  -h, --help                   help for list
      --with-label labels      only run tests with specified label in the form key=value (can be specified multiple times, value is a glob)
      --without-label labels   only run tests without specified label in the form key=value (can be specified multiple times, value is a glob)

Global Flags:
      --config string   config file (default is $HOME/.signadot/config.yaml)
      --debug           enable debug output
  -o, --output string   output format (json|yaml)
```

```
25-05-12 scott@air cli % ./signadot st list
github.com/signadot/cli/tests/fixtures/smart-tests-git/backend/team1/file1.star
github.com/signadot/cli/tests/fixtures/smart-tests-git/backend/team2/file2.star
github.com/signadot/cli/tests/fixtures/smart-tests-git/backend/test.star
github.com/signadot/cli/tests/fixtures/smart-tests-git/frontend/file3.star
```

```
25-05-12 scott@air cli % ./signadot st list -o yaml
- name: github.com/signadot/cli/tests/fixtures/smart-tests-git/backend/team1/file1.star
  path: /Users/scott/Dev/github.com/signadot/cli/tests/fixtures/smart-tests-git/backend/team1/file1.star
  labels:
    area: backend
    suite: integration
    team: team1
- name: github.com/signadot/cli/tests/fixtures/smart-tests-git/backend/team2/file2.star
  path: /Users/scott/Dev/github.com/signadot/cli/tests/fixtures/smart-tests-git/backend/team2/file2.star
  labels:
    area: backend
    suite: integration
    team: team2
- name: github.com/signadot/cli/tests/fixtures/smart-tests-git/backend/test.star
  path: /Users/scott/Dev/github.com/signadot/cli/tests/fixtures/smart-tests-git/backend/test.star
  labels:
    area: backend
    suite: integration
- name: github.com/signadot/cli/tests/fixtures/smart-tests-git/frontend/file3.star
  path: /Users/scott/Dev/github.com/signadot/cli/tests/fixtures/smart-tests-git/frontend/file3.star
  labels:
    suite: integration
    team: frontend
```

```
25-05-12 scott@air cli % ./signadot st list -o yaml -f - < tests/fixtures/smart-tests-git/frontend/file3.star
- name: air-stdin-59669
  path: ""
  labels: {}
```

```
25-05-12 scott@air cli % ./signadot st list --with-label "team=*"
github.com/signadot/cli/tests/fixtures/smart-tests-git/frontend/file3.star
github.com/signadot/cli/tests/fixtures/smart-tests-git/backend/team1/file1.star
github.com/signadot/cli/tests/fixtures/smart-tests-git/backend/team2/file2.star
25-05-12 scott@air cli % ./signadot st list --with-label "team=team2"
github.com/signadot/cli/tests/fixtures/smart-tests-git/backend/team2/file2.star
25-05-12 scott@air cli %
25-05-12 scott@air cli % ./signadot st list --with-label "team=team1"
github.com/signadot/cli/tests/fixtures/smart-tests-git/backend/team1/file1.star
25-05-12 scott@air cli %
25-05-12 scott@air cli % ./signadot st list --without-label "team=team1"
github.com/signadot/cli/tests/fixtures/smart-tests-git/frontend/file3.star
github.com/signadot/cli/tests/fixtures/smart-tests-git/backend/team2/file2.star
github.com/signadot/cli/tests/fixtures/smart-tests-git/backend/test.star
25-05-12 scott@air cli % ./signadot st list --without-label "team=*"
github.com/signadot/cli/tests/fixtures/smart-tests-git/backend/test.star
```
