### PR TITLE
fix get-env secret

### DIFF
--- a/internal/command/sandbox/get_utils.go
+++ b/internal/command/sandbox/get_utils.go
@@ -105,7 +105,7 @@ func extractSBEnvVar(ctx context.Context, kubeClient client.Client, ns string, r
 				Secret: &k8senv.MapKey{
 					Namespace: ns,
 					Name:      key.Name,
-					Key:       vf.ConfigMap.Key,
+					Key:       vf.Secret.Key,
 				},
 			},
 		}, nil


### PR DESCRIPTION
This fixes a nil pointer exception when accessing a custom overriden secret value.