### PR TITLE
rename sandbox ID and add routing key to list output

### DIFF
--- a/internal/command/sandbox/printers.go
+++ b/internal/command/sandbox/printers.go
@@ -18,6 +18,7 @@ import (
 
 type sandboxRow struct {
 	Name        string `sdtab:"NAME"`
+	RoutingKey  string `sdtab:"ROUTING KEY"`
 	Description string `sdtab:"DESCRIPTION,trunc"`
 	Cluster     string `sdtab:"CLUSTER"`
 	Created     string `sdtab:"CREATED"`
@@ -35,6 +36,7 @@ func printSandboxTable(out io.Writer, sbs []*models.Sandbox) error {
 
 		t.AddRow(sandboxRow{
 			Name:        sb.Name,
+			RoutingKey:  sb.RoutingKey,
 			Description: sb.Spec.Description,
 			Cluster:     *sb.Spec.Cluster,
 			Created:     timeago.NoMax(timeago.English).Format(createdAt),
@@ -47,8 +49,8 @@ func printSandboxTable(out io.Writer, sbs []*models.Sandbox) error {
 func printSandboxDetails(cfg *config.Sandbox, out io.Writer, sb *models.Sandbox) error {
 	tw := tabwriter.NewWriter(out, 0, 0, 3, ' ', 0)
 
-	fmt.Fprintf(tw, "ID:\t%s\n", sb.RoutingKey)
 	fmt.Fprintf(tw, "Name:\t%s\n", sb.Name)
+	fmt.Fprintf(tw, "Routing Key:\t%s\n", sb.RoutingKey)
 	fmt.Fprintf(tw, "Description:\t%s\n", sb.Spec.Description)
 	fmt.Fprintf(tw, "Cluster:\t%s\n", *sb.Spec.Cluster)
 	fmt.Fprintf(tw, "Created:\t%s\n", utils.FormatTimestamp(sb.CreatedAt))


### PR DESCRIPTION
```
25-07-22 scott@air cli % ./signadot sb list
NAME                             ROUTING KEY     DESCRIPTION           CLUSTER         CREATED        STATUS
scott-tests-demo                 xplzwz3xfd4ww                         v0.19.0-xrc.1   9 months ago   Not Ready
demo-create-get-delet-7f08fcfd   ud036luckucfl   No-Op sandbox fo...   v0.19.0-xrc.1   9 months ago   Not Ready
25-07-22 scott@air cli % ./signadot sb get scott-tests-demo
Name:             scott-tests-demo
Routing Key:      xplzwz3xfd4ww
Description:
Cluster:          v0.19.0-xrc.1
Created:          Thu, 24 Oct 2024 10:48:51 CEST (9 months ago)
Updated:          Mon, 07 Jul 2025 11:18:35 CEST (2 weeks ago)
TTL:              - (forever)
Dashboard page:   https://app.signadot.com/sandbox/name/scott-tests-demo
Status:           Not Ready (ClusterCommunication: Error communicating with cluster)
```