### PR TITLE
get-env fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/oklog/run v1.1.0
 	github.com/panta/machineid v1.0.2
 	github.com/signadot/go-sdk v0.3.8-0.20250730210632-13a6fc0827df
-	github.com/signadot/libconnect v0.1.1-0.20250814203329-98381c7863de
+	github.com/signadot/libconnect v0.1.1-0.20250826120501-7f15477d96ff
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/viper v1.11.0
 	github.com/theckman/yacspin v0.13.12
@@ -143,4 +143,5 @@ require (
 
 // Used for local dev
 // replace github.com/signadot/libconnect => ../libconnect/
+
 // replace github.com/signadot/go-sdk => ../go-sdk

--- a/go.sum
+++ b/go.sum
@@ -356,8 +356,8 @@ github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
 github.com/signadot/go-sdk v0.3.8-0.20250730210632-13a6fc0827df h1:3Ii88OxvhZFzNru0tAziGti2XBtwrQqChzcCKKigbjU=
 github.com/signadot/go-sdk v0.3.8-0.20250730210632-13a6fc0827df/go.mod h1:oX12C9I/8QaXcl9XLIrc6bUOYVCOGrYPExe+Sln/3IY=
-github.com/signadot/libconnect v0.1.1-0.20250814203329-98381c7863de h1:nSClpbMu2p7aJMFDSNiEtwYXY4RqoToE+wsHiP0tK9M=
-github.com/signadot/libconnect v0.1.1-0.20250814203329-98381c7863de/go.mod h1:slkLIQlZTXajyc16CmuA2s4E2dcfYpykp9dBYn2Z8Do=
+github.com/signadot/libconnect v0.1.1-0.20250826120501-7f15477d96ff h1:FUnw1FCjpKgnB/+jxpSfepsJBo554jPRBZ+54ztSuQc=
+github.com/signadot/libconnect v0.1.1-0.20250826120501-7f15477d96ff/go.mod h1:slkLIQlZTXajyc16CmuA2s4E2dcfYpykp9dBYn2Z8Do=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/skeema/knownhosts v1.3.1 h1:X2osQ+RAjK76shCbvhHHHVl3ZlgDm8apHEHFqRjnBY8=
 github.com/skeema/knownhosts v1.3.1/go.mod h1:r7KTdC8l4uxWRyK2TpQZ/1o5HaSzh06ePQNxPwTcfiY=

--- a/internal/command/sandbox/get_env.go
+++ b/internal/command/sandbox/get_env.go
@@ -86,11 +86,11 @@ func getEnv(cfg *config.SandboxGetEnv, out, errOut io.Writer, name string) error
 	if err := printForbidden(errOut, containerEnv.Forbidden); err != nil {
 		return err
 	}
-
-	resEnv = k8senv.ResolveEnv(ctx, resEnv)
-	if err != nil {
+	if err := printWarnings(errOut, containerEnv.Warnings); err != nil {
 		return err
 	}
+
+	resEnv = k8senv.ResolveEnv(ctx, resEnv)
 
 	// print output
 	return printEnv(out, cfg.OutputFormat, resEnv)

--- a/internal/command/sandbox/get_utils.go
+++ b/internal/command/sandbox/get_utils.go
@@ -222,7 +222,20 @@ func printForbidden(out io.Writer, forbidden []k8senv.Forbidden) error {
 	}
 	for i := range forbidden {
 		f := &forbidden[i]
-		_, err = fmt.Fprintf(out, "\t- %s %s/%s", f.Kind, f.Namespace, f.Name)
+		_, err = fmt.Fprintf(out, "\t- %s %s/%s\n", f.Kind, f.Namespace, f.Name)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func printWarnings(out io.Writer, warnings []string) error {
+	if len(warnings) == 0 {
+		return nil
+	}
+	for _, warning := range warnings {
+		_, err := fmt.Fprintf(out, "WARNING %s\n", warning)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Fixes https://github.com/signadot/community/issues/102

depends on https://github.com/signadot/libconnect/pull/116

```
25-08-26 scott@air cli % ./signadot sb get-env local-env
WARNING unsupported field ref: status.podIPs
export SIGNADOT_BASELINE_KIND='Deployment'              # constant
export SIGNADOT_BASELINE_NAMESPACE='hotrod-devmesh'     # fieldRef: metadata.namespace
export XYZ='v123'                                       # fieldRef: metadata.labels['e2e.signadot.com/version']
export SIGNADOT_BASELINE_NAME='location'                # constant
export OTEL_EXPORTER_OTLP_ENDPOINT='http://jaeger:4318' # constant
export MYSQL_HOST='mysql'                               # constant
export MYSQL_PORT='3306'                                # constant
export MYSQL_PASS='abc'                                 # constant
export SIGNADOT_SANDBOX_NAME='local-env'                # constant (override)
export SIGNADOT_SANDBOX_ROUTING_KEY='7yl13nt3n0nkb'     # constant (override)
25-08-26 scott@air cli % eval $(./signadot sb get-env local-env )
WARNING unsupported field ref: status.podIPs
```