### PR TITLE
This PR fixes a bug with slow fork-exec

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/oklog/run v1.1.0
 	github.com/panta/machineid v1.0.2
 	github.com/signadot/go-sdk v0.3.8-0.20250828202325-847d6b735fc1
-	github.com/signadot/libconnect v0.1.1-0.20250814203329-98381c7863de
+	github.com/signadot/libconnect v0.1.1-0.20250909135527-85dee197b1f5
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/viper v1.11.0
 	github.com/theckman/yacspin v0.13.12
@@ -143,4 +143,5 @@ require (
 
 // Used for local dev
 // replace github.com/signadot/libconnect => ../libconnect/
+
 // replace github.com/signadot/go-sdk => ../go-sdk

--- a/go.sum
+++ b/go.sum
@@ -356,8 +356,8 @@ github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
 github.com/signadot/go-sdk v0.3.8-0.20250828202325-847d6b735fc1 h1:nq8WXCqtlN8J615VVwdotSM0493W3EEr1VHOucDf5Rc=
 github.com/signadot/go-sdk v0.3.8-0.20250828202325-847d6b735fc1/go.mod h1:qgQQHdnLzfDIWJwTvVCfBr5hfPC6pgl/N8yiAMozQLc=
-github.com/signadot/libconnect v0.1.1-0.20250814203329-98381c7863de h1:nSClpbMu2p7aJMFDSNiEtwYXY4RqoToE+wsHiP0tK9M=
-github.com/signadot/libconnect v0.1.1-0.20250814203329-98381c7863de/go.mod h1:slkLIQlZTXajyc16CmuA2s4E2dcfYpykp9dBYn2Z8Do=
+github.com/signadot/libconnect v0.1.1-0.20250909135527-85dee197b1f5 h1:Djj9eiOrieTi3HyTGotyaGr+4lwzzohzPwNu9lE05WY=
+github.com/signadot/libconnect v0.1.1-0.20250909135527-85dee197b1f5/go.mod h1:slkLIQlZTXajyc16CmuA2s4E2dcfYpykp9dBYn2Z8Do=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/skeema/knownhosts v1.3.1 h1:X2osQ+RAjK76shCbvhHHHVl3ZlgDm8apHEHFqRjnBY8=
 github.com/skeema/knownhosts v1.3.1/go.mod h1:r7KTdC8l4uxWRyK2TpQZ/1o5HaSzh06ePQNxPwTcfiY=

--- a/internal/command/locald/locald.go
+++ b/internal/command/locald/locald.go
@@ -39,12 +39,12 @@ func run(cfg *config.LocalDaemon, args []string) error {
 	signal.Ignore(syscall.SIGHUP)
 
 	if err := cfg.InitLocalDaemon(); err != nil {
-		return err
+		return fmt.Errorf("could not init local daemon config: %w", err)
 	}
 	ciConfig := cfg.ConnectInvocationConfig
 	log, err := getLogger(ciConfig, cfg.RootManager)
 	if err != nil {
-		return err
+		return fmt.Errorf("could not get logger: %w", err)
 	}
 	pidFile := ciConfig.GetPIDfile(cfg.RootManager)
 
@@ -53,7 +53,7 @@ func run(cfg *config.LocalDaemon, args []string) error {
 		// it is is independent of PATH.
 		binary, err := exec.LookPath(os.Args[0])
 		if err != nil {
-			return err
+			return fmt.Errorf("locald --daemon: error finding executable path for %s: %w", os.Args[0], err)
 		}
 		args := []string{"locald"}
 		env := []string{
@@ -75,15 +75,21 @@ func run(cfg *config.LocalDaemon, args []string) error {
 		cmd.Env = env
 
 		if err := cmd.Start(); err != nil {
-			return err
+			return fmt.Errorf("locald %s --daemon: error starting command binary=%s args=%v: %w", mgr(cfg), binary, cmd.Args, err)
 		}
 		// and check to see that it succeeded
-		return processes.WaitReady(pidFile, time.Second, cmd.Process, log)
+		if err := processes.WaitReady(pidFile, 30*time.Second, cmd.Process, log); err != nil {
+			// we can't return an error here because signadot local connect
+			// won't get cleaned up but will continue running and can say that it
+			// is working (for example airlock tool slows this down).
+			log.Warn(fmt.Sprintf("error checking locald %s --daemon sub-process ready", mgr(cfg)), "binary", binary, "args", cmd.Args)
+		}
+		return nil
 	}
 
 	// write our pidfile
 	if err := processes.WritePIDFile(pidFile); err != nil {
-		return err
+		return fmt.Errorf("locald %s error writing pid file: %w", mgr(cfg), err)
 	}
 	// make sure pidfile perms are correct
 	if err := os.Chown(pidFile, ciConfig.User.UID, ciConfig.User.GID); err != nil {
@@ -122,4 +128,11 @@ func getLogger(ciConfig *config.ConnectInvocationConfig, isRootManager bool) (*s
 		Level: logLevel,
 	}))
 	return log, nil
+}
+
+func mgr(cfg *config.LocalDaemon) string {
+	if cfg.RootManager {
+		return "root-manager"
+	}
+	return "sandbox-manager"
 }

--- a/internal/locald/rootmanager/sbmgr_monitor.go
+++ b/internal/locald/rootmanager/sbmgr_monitor.go
@@ -65,6 +65,9 @@ func (mon *sbmgrMonitor) getRunSandboxCmd(ciConfig *config.ConnectInvocationConf
 		fmt.Sprintf("PATH=%s", ciConfig.User.UIDPath),
 		fmt.Sprintf("SIGNADOT_LOCAL_CONNECT_INVOCATION_CONFIG=%s", string(ciBytes)),
 	)
+	if ciConfig.Debug {
+		mon.log.Debug("root-manager launch sbmgr", "pid", os.Getpid(), "uid", os.Getuid(), "euid", os.Geteuid(), "binary", binary, "args", cmd.Args)
+	}
 	return cmd, nil
 }
 
@@ -152,7 +155,7 @@ func (mon *sbmgrMonitor) stop() error {
 	}
 	process, err := os.FindProcess(pid)
 	if err != nil {
-		return err
+		return fmt.Errorf("root-manager sbmgr-monitor: could not find process %d: %w", pid, err)
 	}
 
 	// Establish a connection with sandbox manager

--- a/internal/locald/run.go
+++ b/internal/locald/run.go
@@ -18,7 +18,7 @@ func RunSandboxManager(cfg *config.LocalDaemon, log *slog.Logger, args []string)
 		"locald-component", "sandbox-manager",
 		"pid", os.Getpid()))
 	if err != nil {
-		return err
+		return fmt.Errorf("locald sandbox-manager error creating sandbox-manager: %w", err)
 	}
 	return sbMgr.Run(ctx)
 }


### PR DESCRIPTION
Some tools, such as https://www.airlockdigital.com interfere with fork/exec pattern in that there is an increased delay between `cmd.Start` and when that command actually starts running.

In our fork/exec chain for `signadot local`, after `cmd.Start()` we check if the sub-process is ready in the sense of writing its pid file.

This PR
1. increases the timeout for this from 1 to 30sec; and
2. does not return an error if there is a timeout waiting for the sub-process to be ready because that causes `signadot local connect` to report an error but not cleanup, but the background process is still there.  Rather it sends a warning to the log.
3. improves error reporting (depends in part on https://github.com/signadot/libconnect/pull/125)