### PR TITLE
Improve Color Handling in TUI

### DIFF
--- a/internal/trafficwatch/filemanager/utils.go
+++ b/internal/trafficwatch/filemanager/utils.go
@@ -28,7 +28,7 @@ func LoadHttpRequest(requestPath string) (*http.Request, error) {
 
 	res, err := http.ReadRequest(bufReader)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read request file: %w", err)
+		return nil, fmt.Errorf("failed to read HTTP request from %s: %w", requestPath, err)
 	}
 
 	return res, nil
@@ -45,7 +45,7 @@ func LoadHttpResponse(responsePath string) (*http.Response, error) {
 
 	res, err := http.ReadResponse(bufReader, &http.Request{})
 	if err != nil {
-		return nil, fmt.Errorf("failed to read response file: %w", err)
+		return nil, fmt.Errorf("failed to read HTTP response from %s: %w", responsePath, err)
 	}
 
 	return res, nil

--- a/internal/tui/colors/colors.go
+++ b/internal/tui/colors/colors.go
@@ -1,0 +1,20 @@
+package colors
+
+import "github.com/charmbracelet/lipgloss"
+
+var (
+	White     = lipgloss.Color("#ffffff")
+	LightGray = lipgloss.Color("#c0c0c0")
+	Gray      = lipgloss.Color("#8a8a8a")
+	Black     = lipgloss.Color("#000000")
+
+	Red    = lipgloss.Color("#ff0000")
+	Orange = lipgloss.Color("#ff8700")
+
+	Blue       = lipgloss.Color("#5D95FF")
+	BrightBlue = lipgloss.Color("#5fd7ff")
+
+	Cyan       = lipgloss.Color("#008080")
+	BrightCyan = lipgloss.Color("#00ffff")
+	Green      = lipgloss.Color("#afff5f")
+)

--- a/internal/tui/components/empty_screen.go
+++ b/internal/tui/components/empty_screen.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
+	"github.com/signadot/cli/internal/tui/colors"
 )
 
 // EmptyScreenComponent represents a reusable empty state component
@@ -61,14 +62,14 @@ func (e *EmptyScreenComponent) Render() string {
 
 	titleStyle := lipgloss.NewStyle().
 		Bold(true).
-		Foreground(lipgloss.Color("blue")).
+		Foreground(colors.Blue).
 		MarginBottom(1)
 	content.WriteString(titleStyle.Render(e.Title))
 	content.WriteString("\n\n")
 
 	if e.Description != "" {
 		descStyle := lipgloss.NewStyle().
-			Foreground(lipgloss.Color("gray")).
+			Foreground(colors.LightGray).
 			MarginBottom(1)
 
 		centeredDescription := lipgloss.Place(e.width, e.height-20, lipgloss.Center, lipgloss.Top, e.Description)
@@ -79,7 +80,7 @@ func (e *EmptyScreenComponent) Render() string {
 	if e.Action != "" {
 		actionStyle := lipgloss.NewStyle().
 			Italic(true).
-			Foreground(lipgloss.Color("yellow"))
+			Foreground(colors.Orange)
 		content.WriteString(actionStyle.Render(e.Action))
 	}
 

--- a/internal/tui/components/help.go
+++ b/internal/tui/components/help.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/charmbracelet/bubbles/help"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/signadot/cli/internal/tui/colors"
 )
 
 // HelpComponent represents a reusable help component using bubbles help
@@ -56,7 +57,7 @@ func (h *HelpComponent) Render() string {
 	// Title
 	titleStyle := lipgloss.NewStyle().
 		Bold(true).
-		Foreground(lipgloss.Color("blue"))
+		Foreground(colors.Blue)
 	content.WriteString(titleStyle.Render(h.Title))
 	content.WriteString("\n\n")
 

--- a/internal/tui/components/status.go
+++ b/internal/tui/components/status.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/charmbracelet/lipgloss"
+	"github.com/signadot/cli/internal/tui/colors"
 )
 
 // StatusComponent represents a reusable status component
@@ -60,18 +61,18 @@ func (s *StatusComponent) Render(followMode bool) string {
 
 	if followMode {
 		followModeText := lipgloss.NewStyle().
-			Foreground(lipgloss.Color("25")).
+			Foreground(colors.Blue).
 			Bold(true).
 			Render("[FOLLOW MODE]")
 		content.WriteString(followModeText + " ")
 	}
 
-	statusColor := lipgloss.Color("green")
+	statusColor := colors.Green
 	switch s.Status {
 	case "error", "failed":
-		statusColor = lipgloss.Color("red")
+		statusColor = colors.Red
 	case "warning":
-		statusColor = lipgloss.Color("yellow")
+		statusColor = colors.Orange
 	}
 
 	statusText := lipgloss.NewStyle().

--- a/internal/tui/views/trafficwatch/left_pane.go
+++ b/internal/tui/views/trafficwatch/left_pane.go
@@ -10,6 +10,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/signadot/cli/internal/trafficwatch/filemanager"
+	"github.com/signadot/cli/internal/tui/colors"
 )
 
 type LeftPane struct {
@@ -189,7 +190,7 @@ func (l *LeftPane) View() string {
 
 	header := lipgloss.NewStyle().
 		Bold(true).
-		Foreground(lipgloss.Color("#5D95FF")).
+		Foreground(colors.Blue).
 		Render(fmt.Sprintf("Traffic Watch (%d)", len(l.requests)))
 	content.WriteString(header)
 	content.WriteString("\n\n")
@@ -225,57 +226,49 @@ func (l *LeftPane) renderRequestItem(req *filemanager.RequestMetadata, selected 
 		parsedURL = &url.URL{Path: req.RequestURI}
 	}
 
-	cMethodGet := lipgloss.Color("10")      // bright green
-	cMethodPost := lipgloss.Color("14")     // cyan
-	cMethodPut := lipgloss.Color("214")     // orange
-	cMethodDel := lipgloss.Color("9")       // red
-	cHost := lipgloss.Color("245")          // light gray
-	cPath := lipgloss.Color("81")           // bright blue
-	cSelectedAccent := lipgloss.Color("63") // blue accent (selection marker)
-
 	var methodColor lipgloss.Color
 	switch strings.ToUpper(req.Method) {
 	case "GET":
-		methodColor = cMethodGet
+		methodColor = colors.Green
 	case "POST":
-		methodColor = cMethodPost
+		methodColor = colors.BrightCyan
 	case "PUT":
-		methodColor = cMethodPut
+		methodColor = colors.Orange
 	case "DELETE":
-		methodColor = cMethodDel
+		methodColor = colors.Red
 	default:
-		methodColor = lipgloss.Color("7") // neutral gray
+		methodColor = colors.LightGray
 	}
 
-	methodStyle := lipgloss.NewStyle().Foreground(methodColor).Bold(true).Width(6)
-	hostStyle := lipgloss.NewStyle().Foreground(cHost)
-	pathStyle := lipgloss.NewStyle().Foreground(cPath)
-
-	method := methodStyle.Render(strings.ToUpper(req.Method))
-	host := hostStyle.Render(parsedURL.Host)
-	fullPath := pathStyle.Render(parsedURL.Path)
+	method := lipgloss.NewStyle().Foreground(methodColor).Bold(true).Width(6).
+		Render(strings.ToUpper(req.Method))
+	host := lipgloss.NewStyle().Foreground(colors.Gray).
+		Render(parsedURL.Host)
+	fullPath := lipgloss.NewStyle().Foreground(colors.BrightBlue).
+		Render(parsedURL.Path)
 	if parsedURL.RawQuery != "" {
 		fullPath += "?" + parsedURL.RawQuery
 	}
-
 	if parsedURL.Fragment != "" {
 		fullPath += "#" + parsedURL.Fragment
 	}
 
 	// Format timestamp (strip milliseconds and timezone)
-	formattedTime := req.DoneAt.Format("2006-01-02 15:04:05")
+	formattedTime := lipgloss.NewStyle().Foreground(colors.White).
+		Render(req.DoneAt.Format("2006-01-02 15:04:05"))
 
-	// Properly render protocol
-	var protocol string
+	// Properly render proto
+	var proto string
 	switch req.Protocol {
 	case filemanager.ProtocolGRPC:
-		protocol = "gRPC"
+		proto = "gRPC"
 	default:
-		protocol = strings.ToUpper(string(req.Protocol))
+		proto = strings.ToUpper(string(req.Protocol))
 	}
+	proto = lipgloss.NewStyle().Foreground(colors.White).Render(proto)
 
 	// date-time  protocol  host
-	line1 := fmt.Sprintf("%s  %-5s  ", formattedTime, protocol)
+	line1 := fmt.Sprintf("%s  %-5s  ", formattedTime, proto)
 	line1 += truncateURL(host, l.width-lipgloss.Width(line1)-1)
 	// method  fullPath
 	line2 := fmt.Sprintf("%-6s  ", method)
@@ -284,7 +277,7 @@ func (l *LeftPane) renderRequestItem(req *filemanager.RequestMetadata, selected 
 	content := lipgloss.NewStyle().Width(l.width).Render(line1 + "\n" + line2)
 	if selected {
 		indicator := lipgloss.NewStyle().
-			Foreground(cSelectedAccent).
+			Foreground(colors.Blue).
 			Render("▌")
 
 		lines := strings.Split(content, "\n")
@@ -301,7 +294,7 @@ func (l *LeftPane) renderRequestItem(req *filemanager.RequestMetadata, selected 
 func (l *LeftPane) renderEmptyState() string {
 	return lipgloss.NewStyle().
 		Align(lipgloss.Center).
-		Foreground(lipgloss.Color("gray")).
+		Foreground(colors.LightGray).
 		Render("No traffic data available")
 }
 

--- a/internal/tui/views/trafficwatch/logs_view.go
+++ b/internal/tui/views/trafficwatch/logs_view.go
@@ -11,6 +11,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/signadot/cli/internal/trafficwatch/filemanager"
+	"github.com/signadot/cli/internal/tui/colors"
 	"github.com/signadot/cli/internal/tui/components"
 	"github.com/signadot/cli/internal/tui/views"
 )
@@ -202,7 +203,7 @@ func (l *LogsView) View() string {
 func (l *LogsView) headerView() string {
 	title := lipgloss.NewStyle().
 		Bold(true).
-		Foreground(lipgloss.Color("blue")).
+		Foreground(colors.Blue).
 		Render(fmt.Sprintf("Logs (%d entries) - %s", len(l.logs), l.logFile))
 
 	if l.ready {
@@ -219,7 +220,7 @@ func (l *LogsView) footerView() string {
 	}
 
 	info := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("gray")).
+		Foreground(colors.LightGray).
 		Render(fmt.Sprintf("%3.f%%", l.viewport.ScrollPercent()*100))
 
 	line := strings.Repeat("─", max(0, l.viewport.Width-lipgloss.Width(info)))
@@ -253,21 +254,21 @@ func max(a, b int) int {
 func (l *LogsView) renderLogLine(entry filemanager.LogEntry) string {
 	// Create a styled timestamp
 	timestamp := entry.Timestamp.Format("15:04:05")
-	timestampStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("gray"))
+	timestampStyle := lipgloss.NewStyle().Foreground(colors.LightGray)
 
 	// Create level styling based on slog.Level
 	var levelStyle lipgloss.Style
 	switch entry.Level {
 	case slog.LevelError:
-		levelStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("red")).Bold(true)
+		levelStyle = lipgloss.NewStyle().Foreground(colors.Red).Bold(true)
 	case slog.LevelWarn:
-		levelStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("yellow")).Bold(true)
+		levelStyle = lipgloss.NewStyle().Foreground(colors.Orange).Bold(true)
 	case slog.LevelInfo:
-		levelStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("blue"))
+		levelStyle = lipgloss.NewStyle().Foreground(colors.Blue)
 	case slog.LevelDebug:
-		levelStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("gray"))
+		levelStyle = lipgloss.NewStyle().Foreground(colors.LightGray)
 	default:
-		levelStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("white"))
+		levelStyle = lipgloss.NewStyle().Foreground(colors.White)
 	}
 
 	// Format the log line
@@ -283,7 +284,7 @@ func (l *LogsView) renderLogLine(entry filemanager.LogEntry) string {
 	line.WriteString(" ")
 
 	// Add message
-	messageStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("white"))
+	messageStyle := lipgloss.NewStyle().Foreground(colors.White)
 	line.WriteString(messageStyle.Render(entry.Message))
 
 	// Add all attributes with different colors for different types
@@ -297,17 +298,17 @@ func (l *LogsView) renderLogLine(entry filemanager.LogEntry) string {
 		// Color-code different types of attributes
 		switch {
 		case strings.HasPrefix(key, "request."):
-			attrStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("23"))
+			attrStyle = lipgloss.NewStyle().Foreground(colors.Cyan)
 		case key == "sandbox":
-			attrStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#5D95FF"))
+			attrStyle = lipgloss.NewStyle().Foreground(colors.Blue)
 		case key == "error":
-			attrStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#FF0000"))
+			attrStyle = lipgloss.NewStyle().Foreground(colors.Red)
 		case strings.Contains(key, "time") || strings.Contains(key, "At"):
-			attrStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#5D95FF"))
+			attrStyle = lipgloss.NewStyle().Foreground(colors.Blue)
 		case key == "level" || key == "msg":
 			continue
 		default:
-			attrStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("yellow"))
+			attrStyle = lipgloss.NewStyle().Foreground(colors.Orange)
 		}
 
 		line.WriteString(" ")

--- a/internal/tui/views/trafficwatch/main_view.go
+++ b/internal/tui/views/trafficwatch/main_view.go
@@ -11,6 +11,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/signadot/cli/internal/config"
 	"github.com/signadot/cli/internal/trafficwatch/filemanager"
+	"github.com/signadot/cli/internal/tui/colors"
 	"github.com/signadot/cli/internal/tui/components"
 	"github.com/signadot/cli/internal/tui/views"
 )
@@ -404,37 +405,33 @@ func (m *MainView) renderWithDataState() string {
 	paneWidth := m.width/2 - 2
 	leftStyle := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
-		BorderForeground(lipgloss.Color("#5D95FF")).
+		BorderForeground(colors.Blue).
 		Padding(1).
 		Width(paneWidth).
 		Height(m.leftPane.height)
 
 	rightStyle := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
-		BorderForeground(lipgloss.Color("#2E77FF")).
+		BorderForeground(colors.Blue).
 		Padding(1).
 		Width(paneWidth).
 		Height(m.rightPane.height)
 	if m.focus == "left" {
 		leftStyle = leftStyle.
-			BorderForeground(lipgloss.Color("#5D95FF")).
+			BorderForeground(colors.Blue).
 			BorderStyle(lipgloss.ThickBorder()).
-			Background(lipgloss.Color("black")).
-			Foreground(lipgloss.Color("white"))
+			Foreground(colors.White)
 		rightStyle = rightStyle.
-			BorderForeground(lipgloss.Color("gray")).
-			Background(lipgloss.Color("black")).
-			Foreground(lipgloss.Color("gray"))
+			BorderForeground(colors.LightGray).
+			Foreground(colors.LightGray)
 	} else {
 		rightStyle = rightStyle.
-			BorderForeground(lipgloss.Color("#2E77FF")).
+			BorderForeground(colors.Blue).
 			BorderStyle(lipgloss.ThickBorder()).
-			Background(lipgloss.Color("black")).
-			Foreground(lipgloss.Color("white"))
+			Foreground(colors.White)
 		leftStyle = leftStyle.
-			BorderForeground(lipgloss.Color("gray")).
-			Background(lipgloss.Color("black")).
-			Foreground(lipgloss.Color("gray"))
+			BorderForeground(colors.LightGray).
+			Foreground(colors.LightGray)
 	}
 
 	leftPane := leftStyle.Render(leftContent)

--- a/internal/tui/views/trafficwatch/right_pane.go
+++ b/internal/tui/views/trafficwatch/right_pane.go
@@ -10,17 +10,18 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/signadot/cli/internal/trafficwatch/filemanager"
+	"github.com/signadot/cli/internal/tui/colors"
 	"github.com/signadot/cli/internal/tui/components"
 )
 
 var (
 	keyStyle = lipgloss.NewStyle().
 			Bold(true).
-			Foreground(lipgloss.Color("#5D95FF")).
+			Foreground(colors.Blue).
 			Width(18)
 
 	valueStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("white"))
+			Foreground(colors.White)
 )
 
 // RightPaneTab represents the active tab
@@ -150,7 +151,7 @@ func (r *RightPane) View() string {
 // renderTabBar renders the tab bar
 func (r *RightPane) renderTabBar(isFocused bool) string {
 	tabs := []string{"Request", "Response"}
-	tabColors := []string{"#008080", "#008080"}
+	tabColors := []lipgloss.Color{colors.Cyan, colors.Cyan}
 
 	var tabStrings []string
 	for i, tab := range tabs {
@@ -160,21 +161,21 @@ func (r *RightPane) renderTabBar(isFocused bool) string {
 
 		if int(r.activeTab) == i {
 			style = style.
-				Foreground(lipgloss.Color(tabColors[i])).
+				Foreground(tabColors[i]).
 				Bold(true)
 
 			switch isFocused {
 			case true:
 				style = style.
-					Background(lipgloss.Color(tabColors[i])).
-					Foreground(lipgloss.Color("white"))
+					Background(tabColors[i]).
+					Foreground(colors.White)
 			case false:
 				style = style.
 					Underline(true)
 			}
 		} else {
 			style = style.
-				Foreground(lipgloss.Color(tabColors[i]))
+				Foreground(tabColors[i])
 		}
 
 		tabStrings = append(tabStrings, style.Render(tab))
@@ -216,16 +217,15 @@ func (r *RightPane) renderRequestTab(reqMeta *filemanager.RequestMetadata, req *
 	var content strings.Builder
 
 	if err != nil {
-		content.WriteString(lipgloss.NewStyle().
-			Foreground(lipgloss.Color("red")).
-			Render(err.Error()))
+		// render error
+		r.renderError(&content, err)
 		return content.String()
 	}
 
 	// render general section
 	content.WriteString(lipgloss.NewStyle().
 		Bold(true).
-		Foreground(lipgloss.Color("#008080")).
+		Foreground(colors.Cyan).
 		Render("General"))
 	content.WriteString("\n\n")
 	content.WriteString(r.getLineRenderMeta("ID", reqMeta.MiddlewareRequestID))
@@ -241,7 +241,7 @@ func (r *RightPane) renderRequestTab(reqMeta *filemanager.RequestMetadata, req *
 	// render headers section
 	content.WriteString(lipgloss.NewStyle().
 		Bold(true).
-		Foreground(lipgloss.Color("#008080")).
+		Foreground(colors.Cyan).
 		Render("Headers"))
 	content.WriteString("\n\n")
 
@@ -260,23 +260,15 @@ func (r *RightPane) renderResponseTab(reqMeta *filemanager.RequestMetadata, resp
 	var content strings.Builder
 
 	if err != nil {
-		content.WriteString(lipgloss.NewStyle().
-			Foreground(lipgloss.Color("red")).
-			Render(err.Error()))
-		return content.String()
-	}
-
-	if resp.StatusCode == 0 {
-		content.WriteString(lipgloss.NewStyle().
-			Foreground(lipgloss.Color("gray")).
-			Render("No response data available"))
+		// render error
+		r.renderError(&content, err)
 		return content.String()
 	}
 
 	// render general section
 	content.WriteString(lipgloss.NewStyle().
 		Bold(true).
-		Foreground(lipgloss.Color("#008080")).
+		Foreground(colors.Cyan).
 		Render("General"))
 	content.WriteString("\n\n")
 	content.WriteString(r.getLineRenderMeta("Status", resp.Status))
@@ -288,7 +280,7 @@ func (r *RightPane) renderResponseTab(reqMeta *filemanager.RequestMetadata, resp
 	// render headers section
 	content.WriteString(lipgloss.NewStyle().
 		Bold(true).
-		Foreground(lipgloss.Color("#008080")).
+		Foreground(colors.Cyan).
 		Render("Headers"))
 	content.WriteString("\n\n")
 
@@ -300,6 +292,20 @@ func (r *RightPane) renderResponseTab(reqMeta *filemanager.RequestMetadata, resp
 	r.renderBody(&content, nil, resp)
 
 	return content.String()
+}
+
+func (r *RightPane) renderError(content *strings.Builder, err error) {
+	if err == nil {
+		return
+	}
+
+	prefix := lipgloss.NewStyle().
+		Foreground(colors.Red).
+		Bold(true).
+		Render("Error: ")
+
+	content.WriteString(lipgloss.NewStyle().Width(r.width - 5).
+		Render(prefix + err.Error()))
 }
 
 func (r *RightPane) renderBody(content *strings.Builder, req *http.Request, resp *http.Response) {
@@ -321,7 +327,7 @@ func (r *RightPane) renderBody(content *strings.Builder, req *http.Request, resp
 	content.WriteString("\n")
 	content.WriteString(lipgloss.NewStyle().
 		Bold(true).
-		Foreground(lipgloss.Color("#008080")).
+		Foreground(colors.Cyan).
 		Render("Body"))
 	content.WriteString("\n\n")
 
@@ -354,8 +360,7 @@ func (r *RightPane) renderBody(content *strings.Builder, req *http.Request, resp
 	}
 
 	bodyStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("white")).
-		Background(lipgloss.Color("black")).
+		Foreground(colors.White).
 		Padding(1).
 		Width(r.width - 6).
 		Border(lipgloss.RoundedBorder())


### PR DESCRIPTION
This is an attempt to normalize the colors we use in TUI (removing broken references to colors, like "red" or "gray").
Some minor improvements in error reporting are included too.

@davixcky, @foxish feel free to change any of those color, my intention was to normalize them (and fix broken references) not to define the actual color schema.

E.g.:

- Error display

<img width="1865" height="302" alt="Screenshot from 2025-10-31 11-23-09" src="https://github.com/user-attachments/assets/f9cd2c09-56ef-4fb0-a059-98e249f604c5" />

<img width="3710" height="225" alt="Screenshot from 2025-10-31 11-31-36" src="https://github.com/user-attachments/assets/10eb1ea5-f9cb-4741-99f5-44f67f0e72b8" />

- Colors

<img width="3689" height="1902" alt="Screenshot from 2025-10-31 11-23-38" src="https://github.com/user-attachments/assets/042c846b-f25e-4a19-bcff-a77a2b7d7387" />


