### PR TITLE
Traffic record: don't crash if --inspect and --short specified

### DIFF
--- a/internal/command/traffic/record.go
+++ b/internal/command/traffic/record.go
@@ -91,6 +91,9 @@ func record(rootCtx context.Context, cfg *config.TrafficWatch, defaultDir string
 		if cfg.Clean {
 			return fmt.Errorf("only one of --short or --clean can be provided")
 		}
+		if cfg.TuiMode {
+			return fmt.Errorf("--inspect is not supported when running with --short")
+		}
 	}
 
 	// define output dir


### PR DESCRIPTION
Don't crash if `--inspect` and `--short` specified, instead exit gracefully and call it unsupported.