### PR TITLE
Fix override text printed once command is started

### DIFF
--- a/internal/command/local/override/override.go
+++ b/internal/command/local/override/override.go
@@ -114,14 +114,14 @@ func runOverride(rootCtx context.Context, out, errOut io.Writer,
 	if len(cfg.ExcludedStatusCodes) > 0 {
 		codes := strings.Trim(strings.Join(strings.Fields(fmt.Sprint(cfg.ExcludedStatusCodes)), ","), "[]")
 		fmt.Fprintf(out, "* If your local service (%s) responds with status code(s) %s:\n", bold(cfg.To), codes)
-		fmt.Fprintf(out, "    -> Request is forwarded to the sandbox (%s).\n", cfg.Sandbox)
+		fmt.Fprintf(out, "    -> Request is forwarded to the sandbox (%s).\n", bold(cfg.Sandbox))
 		fmt.Fprintf(out, "* Otherwise:\n")
 		fmt.Fprintf(out, "    -> Response from your local service (%s) is returned to the client.\n", bold(cfg.To))
 	} else {
 		fmt.Fprintf(out, "* If your local service (%s) responds with header `sd-override: true`:\n", bold(cfg.To))
 		fmt.Fprintf(out, "    -> Response from your local service (%s) is returned to the client.\n", bold(cfg.To))
 		fmt.Fprintf(out, "* Otherwise:\n")
-		fmt.Fprintf(out, "    -> Request is forwarded to the sandbox (%s).\n", cfg.Sandbox)
+		fmt.Fprintf(out, "    -> Request is forwarded to the sandbox (%s).\n", bold(cfg.Sandbox))
 	}
 	fmt.Fprintf(out, "\n")
 


### PR DESCRIPTION
Fixes https://github.com/signadot/cli/issues/243

Case 1:
<img width="873" height="250" alt="Screenshot 2025-10-31 at 9 21 14 AM" src="https://github.com/user-attachments/assets/f5d1df94-22cf-4bac-905d-d6a5d4945298" />


Case 2:
<img width="873" height="279" alt="Screenshot 2025-10-31 at 9 21 48 AM" src="https://github.com/user-attachments/assets/48770d64-ba98-46df-8169-c0b409e4deaa" />
