### PR TITLE
Add `signadot auth token` command

### DIFF
--- a/internal/command/auth/auth.go
+++ b/internal/command/auth/auth.go
@@ -18,6 +18,7 @@ func New(api *config.API) *cobra.Command {
 		newLogin(cfg),
 		newStatus(cfg),
 		newLogout(cfg),
+		newToken(cfg),
 	)
 
 	return cmd

--- a/internal/command/auth/token.go
+++ b/internal/command/auth/token.go
@@ -20,7 +20,7 @@ func newToken(cfg *config.Auth) *cobra.Command {
 }
 
 func runToken(cfg *config.Auth, out io.Writer) error {
-	token, err := cfg.RefreshBearerToken()
+	token, err := cfg.GetBearerToken()
 	if err != nil {
 		return fmt.Errorf("could not get token: %w", err)
 	}

--- a/internal/command/auth/token.go
+++ b/internal/command/auth/token.go
@@ -1,0 +1,31 @@
+package auth
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/signadot/cli/internal/config"
+	"github.com/spf13/cobra"
+)
+
+func newToken(cfg *config.Auth) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "token",
+		Short: "Print auth token to stdout",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runToken(cfg, cmd.OutOrStdout())
+		},
+	}
+	return cmd
+}
+
+func runToken(cfg *config.Auth, out io.Writer) error {
+	if err := cfg.InitAPIConfig(); err != nil {
+		return err
+	}
+	if cfg.BearerToken == "" {
+		return fmt.Errorf("no bearer token available (API key auth does not provide a token)")
+	}
+	fmt.Fprint(out, cfg.BearerToken)
+	return nil
+}

--- a/internal/command/auth/token.go
+++ b/internal/command/auth/token.go
@@ -20,12 +20,10 @@ func newToken(cfg *config.Auth) *cobra.Command {
 }
 
 func runToken(cfg *config.Auth, out io.Writer) error {
-	if err := cfg.InitAPIConfig(); err != nil {
-		return err
+	token, err := cfg.RefreshBearerToken()
+	if err != nil {
+		return fmt.Errorf("could not get token: %w", err)
 	}
-	if cfg.BearerToken == "" {
-		return fmt.Errorf("no bearer token available (API key auth does not provide a token)")
-	}
-	fmt.Fprint(out, cfg.BearerToken)
+	fmt.Fprint(out, token)
 	return nil
 }

--- a/internal/config/api.go
+++ b/internal/config/api.go
@@ -128,6 +128,26 @@ func (a *API) checkKeyringAuth(authInfo *auth.ResolvedAuth) error {
 	return nil
 }
 
+// RefreshBearerToken forces a token refresh using the stored refresh token,
+// regardless of whether the current token is expired. It returns the new access token.
+func (a *API) RefreshBearerToken() (string, error) {
+	authInfo, err := auth.ResolveAuth()
+	if err != nil {
+		return "", fmt.Errorf("could not resolve auth: %w", err)
+	}
+	if authInfo == nil || authInfo.RefreshToken == "" {
+		return "", fmt.Errorf("no refresh token available")
+	}
+	if err := a.basicInit(); err != nil {
+		return "", err
+	}
+	refreshed, err := a.refreshKeyringAuth(authInfo)
+	if err != nil {
+		return "", err
+	}
+	return refreshed.BearerToken, nil
+}
+
 func (a *API) refreshKeyringAuth(authInfo *auth.ResolvedAuth) (*auth.ResolvedAuth, error) {
 	if err := a.InitUnauthAPIConfig(); err != nil {
 		return nil, err

--- a/internal/config/api.go
+++ b/internal/config/api.go
@@ -128,24 +128,17 @@ func (a *API) checkKeyringAuth(authInfo *auth.ResolvedAuth) error {
 	return nil
 }
 
-// RefreshBearerToken forces a token refresh using the stored refresh token,
-// regardless of whether the current token is expired. It returns the new access token.
-func (a *API) RefreshBearerToken() (string, error) {
-	authInfo, err := auth.ResolveAuth()
-	if err != nil {
-		return "", fmt.Errorf("could not resolve auth: %w", err)
-	}
-	if authInfo == nil || authInfo.RefreshToken == "" {
-		return "", fmt.Errorf("no refresh token available")
-	}
-	if err := a.basicInit(); err != nil {
+// GetBearerToken initializes the API config (refreshing the token if needed)
+// and returns the bearer token. Returns an error if the user is authenticated
+// with an API key instead.
+func (a *API) GetBearerToken() (string, error) {
+	if err := a.InitAPIConfig(); err != nil {
 		return "", err
 	}
-	refreshed, err := a.refreshKeyringAuth(authInfo)
-	if err != nil {
-		return "", err
+	if a.BearerToken == "" {
+		return "", fmt.Errorf("bearer tokens are not used when authenticated with an API key")
 	}
-	return refreshed.BearerToken, nil
+	return a.BearerToken, nil
 }
 
 func (a *API) refreshKeyringAuth(authInfo *auth.ResolvedAuth) (*auth.ResolvedAuth, error) {

--- a/internal/config/api.go
+++ b/internal/config/api.go
@@ -135,7 +135,7 @@ func (a *API) GetBearerToken() (string, error) {
 	if err := a.InitAPIConfig(); err != nil {
 		return "", err
 	}
-	if a.BearerToken == "" {
+	if a.ApiKey != "" {
 		return "", fmt.Errorf("bearer tokens are not used when authenticated with an API key")
 	}
 	return a.BearerToken, nil


### PR DESCRIPTION
## Summary
- Adds \`signadot auth token\` subcommand that prints the bearer token to stdout (no newline) for scripting and piping
- Returns the cached token if still valid; refreshes transparently via the existing \`checkKeyringAuth\` flow only when expired
- Errors with a clear message when using API key auth (no bearer token involved)
- Errors when not authenticated

## Test plan
- [x] \`signadot auth token\` prints a valid bearer token after \`signadot auth login\`
- [x] \`signadot auth token\` returns the cached token without a network call when not expired
- [x] \`signadot auth token\` refreshes automatically when the token is expired (requires an expired token to exercise)
- [x] \`signadot auth token\` errors when not authenticated (requires logging out of keyring)
- [x] \`signadot auth token\` errors with a helpful message when using API key auth
- [x] Output has no trailing newline (\`signadot auth token | wc -c\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)