### PR TITLE
Plan outputs list fixes

### DIFF
--- a/internal/command/planexec/outputs.go
+++ b/internal/command/planexec/outputs.go
@@ -1,6 +1,7 @@
 package planexec
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -16,7 +17,7 @@ func newOutputs(exec *config.PlanExecution) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "outputs EXECUTION_ID",
-		Short: "List outputs of a plan execution",
+		Short: "List all outputs of a plan execution (plan-level and step-level)",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return listOutputs(cfg, cmd.OutOrStdout(), args[0])
@@ -24,6 +25,16 @@ func newOutputs(exec *config.PlanExecution) *cobra.Command {
 	}
 
 	return cmd
+}
+
+// allOutput unifies plan-level and step-level outputs for display.
+type allOutput struct {
+	Name  string `json:"name"`
+	Step  string `json:"step"`
+	Scope string `json:"scope"` // "plan" or "step"
+	Type  string `json:"type"`  // "inline" or "artifact"
+	Size  int64  `json:"size,omitempty"`
+	Ready *bool  `json:"ready,omitempty"`
 }
 
 func listOutputs(cfg *config.PlanExecOutputs, out io.Writer, execID string) error {
@@ -38,18 +49,94 @@ func listOutputs(cfg *config.PlanExecOutputs, out io.Writer, execID string) erro
 		return err
 	}
 
-	var outputs []*models.PlanOutputStatus
-	if resp.Payload.Status != nil {
-		outputs = resp.Payload.Status.Outputs
-	}
+	all := collectAllOutputs(resp.Payload)
+
 	switch cfg.OutputFormat {
 	case config.OutputFormatDefault:
-		return printOutputsTable(out, outputs)
+		return printAllOutputsTable(out, all)
 	case config.OutputFormatJSON:
-		return print.RawJSON(out, outputs)
+		return print.RawJSON(out, all)
 	case config.OutputFormatYAML:
-		return print.RawYAML(out, outputs)
+		return print.RawYAML(out, all)
 	default:
 		return fmt.Errorf("unsupported output format: %q", cfg.OutputFormat)
 	}
+}
+
+func collectAllOutputs(ex *models.PlanExecution) []allOutput {
+	if ex.Status == nil {
+		return nil
+	}
+
+	// Track plan-level output names to avoid duplicating them in step section.
+	planOutputNames := map[string]bool{}
+	var all []allOutput
+
+	// Plan-level outputs.
+	for _, o := range ex.Status.Outputs {
+		step := ""
+		if o.StepRef != nil {
+			step = o.StepRef.StepID
+		}
+		planOutputNames[step+"/"+o.Name] = true
+		all = append(all, allOutput{
+			Name:  o.Name,
+			Step:  step,
+			Scope: "plan",
+			Type:  outputType(o.Artifact),
+			Size:  outputSize(o.Artifact, o.Value),
+			Ready: outputReady(o.Artifact),
+		})
+	}
+
+	// Step-level outputs (skip those already shown as plan-level).
+	for _, s := range ex.Status.Steps {
+		for _, o := range s.Outputs {
+			key := s.ID + "/" + o.Name
+			if planOutputNames[key] {
+				continue
+			}
+			all = append(all, allOutput{
+				Name:  o.Name,
+				Step:  s.ID,
+				Scope: "step",
+				Type:  outputType(o.Artifact),
+				Size:  outputSize(o.Artifact, o.Value),
+				Ready: outputReady(o.Artifact),
+			})
+		}
+	}
+
+	return all
+}
+
+func outputType(a *models.PlanArtifactRef) string {
+	if a != nil {
+		return "artifact"
+	}
+	return "inline"
+}
+
+func outputSize(a *models.PlanArtifactRef, value any) int64 {
+	if a != nil {
+		return a.Size
+	}
+	if value != nil {
+		if s, ok := value.(string); ok {
+			return int64(len(s))
+		}
+		b, err := json.Marshal(value)
+		if err == nil {
+			return int64(len(b))
+		}
+	}
+	return 0
+}
+
+func outputReady(a *models.PlanArtifactRef) *bool {
+	t := true
+	if a != nil {
+		return &a.Ready
+	}
+	return &t
 }

--- a/internal/command/planexec/printers.go
+++ b/internal/command/planexec/printers.go
@@ -155,6 +155,43 @@ func printOutputsTable(out io.Writer, outputs []*models.PlanOutputStatus) error 
 	return t.Flush()
 }
 
+type allOutputRow struct {
+	Name    string `sdtab:"NAME"`
+	Step    string `sdtab:"STEP"`
+	Scope   string `sdtab:"SCOPE"`
+	Storage string `sdtab:"STORAGE"`
+	Size    string `sdtab:"SIZE"`
+	Ready   string `sdtab:"READY"`
+}
+
+func printAllOutputsTable(out io.Writer, outputs []allOutput) error {
+	t := sdtab.New[allOutputRow](out)
+	t.AddHeader()
+	for _, o := range outputs {
+		size := ""
+		ready := "-"
+		if o.Size > 0 {
+			size = units.HumanSize(float64(o.Size))
+		}
+		if o.Ready != nil {
+			if *o.Ready {
+				ready = "true"
+			} else {
+				ready = "false"
+			}
+		}
+		t.AddRow(allOutputRow{
+			Name:    o.Name,
+			Step:    o.Step,
+			Scope:   o.Scope,
+			Storage: o.Type,
+			Size:  size,
+			Ready: ready,
+		})
+	}
+	return t.Flush()
+}
+
 type execRow struct {
 	ID      string `sdtab:"ID"`
 	Plan    string `sdtab:"PLAN"`


### PR DESCRIPTION
## Summary

- Show both plan-level and step-level outputs in `plan x outputs` (previously only plan-level, which was often empty when the compiler didn't wire plan outputs)
- Add SCOPE column (`plan`/`step`) and rename TYPE to STORAGE (`inline`/`artifact`)
- Compute inline output size from value length
- Show READY as `true` for inline outputs (always available)
- Deduplicate: step outputs already shown as plan outputs are skipped

Stacked on #311 (plan run --attach).

## Test plan

- [x] Execution with only step outputs shows them
- [x] Execution with plan outputs shows `scope=plan`, deduplicates step outputs
- [x] Inline outputs show computed size and `ready=true`
- [x] `go build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)