### PR TITLE
Suppress status messages on stderr when using -o json/yaml

### DIFF
--- a/internal/command/plan/compile.go
+++ b/internal/command/plan/compile.go
@@ -66,7 +66,9 @@ func compile(cfg *config.PlanCompile, out, log io.Writer) error {
 		if _, err := plantag.ApplyTag(cfg.Plan, resp.Payload.ID, cfg.Tag); err != nil {
 			return fmt.Errorf("plan compiled (id=%s) but tagging failed: %w", resp.Payload.ID, err)
 		}
-		fmt.Fprintf(log, "Tagged plan %s as %q\n", resp.Payload.ID, cfg.Tag)
+		if cfg.OutputFormat == config.OutputFormatDefault {
+			fmt.Fprintf(log, "Tagged plan %s as %q\n", resp.Payload.ID, cfg.Tag)
+		}
 	}
 
 	switch cfg.OutputFormat {

--- a/internal/command/plan/create.go
+++ b/internal/command/plan/create.go
@@ -54,7 +54,9 @@ func create(cfg *config.PlanCreate, out, log io.Writer) error {
 		if _, err := plantag.ApplyTag(cfg.Plan, resp.Payload.ID, cfg.Tag); err != nil {
 			return fmt.Errorf("plan created (id=%s) but tagging failed: %w", resp.Payload.ID, err)
 		}
-		fmt.Fprintf(log, "Tagged plan %s as %q\n", resp.Payload.ID, cfg.Tag)
+		if cfg.OutputFormat == config.OutputFormatDefault {
+			fmt.Fprintf(log, "Tagged plan %s as %q\n", resp.Payload.ID, cfg.Tag)
+		}
 	}
 
 	switch cfg.OutputFormat {

--- a/internal/command/plan/recompile.go
+++ b/internal/command/plan/recompile.go
@@ -44,7 +44,9 @@ func recompile(cfg *config.PlanRecompile, out, log io.Writer, planID string) err
 		if _, err := plantag.ApplyTag(cfg.Plan, resp.Payload.ID, cfg.Tag); err != nil {
 			return fmt.Errorf("plan recompiled (id=%s) but tagging failed: %w", resp.Payload.ID, err)
 		}
-		fmt.Fprintf(log, "Tagged plan %s as %q\n", resp.Payload.ID, cfg.Tag)
+		if cfg.OutputFormat == config.OutputFormatDefault {
+			fmt.Fprintf(log, "Tagged plan %s as %q\n", resp.Payload.ID, cfg.Tag)
+		}
 	}
 
 	switch cfg.OutputFormat {

--- a/internal/command/plan/run.go
+++ b/internal/command/plan/run.go
@@ -82,7 +82,9 @@ func runPlan(cfg *config.PlanRun, out, log io.Writer, args []string) error {
 		return fmt.Errorf("creating execution: %w", err)
 	}
 	execID := createResp.Payload.ID
-	fmt.Fprintf(log, "Created execution %s for plan %s\n", execID, planID)
+	if cfg.OutputFormat == config.OutputFormatDefault {
+		fmt.Fprintf(log, "Created execution %s for plan %s\n", execID, planID)
+	}
 
 	// Fire-and-forget mode.
 	if !cfg.Wait {
@@ -229,7 +231,11 @@ func pollExecution(ctx context.Context, cfg *config.PlanRun, log io.Writer, exec
 		defer cancel()
 	}
 
-	spin := spinner.Start(log, "Execution")
+	spinWriter := log
+	if cfg.OutputFormat != config.OutputFormatDefault {
+		spinWriter = io.Discard
+	}
+	spin := spinner.Start(spinWriter, "Execution")
 	defer spin.Stop()
 
 	ticker := time.NewTicker(2 * time.Second)


### PR DESCRIPTION
## Summary
- Suppress "Tagged plan..." message on stderr in `plan compile`, `plan create`, and `plan recompile` when `-o json` or `-o yaml` is used
- Suppress "Created execution..." message and spinner on stderr in `plan run` when `-o json` or `-o yaml` is used
- Messages still appear in default (human-readable) output mode

These messages go to stderr (not stdout), so they don't technically break JSON parsing when stdout is piped directly. However, they do break common patterns like `command 2>&1 | jq .` and add noise when structured output is requested.

## Reproduce (before)

```
$ signadot plan compile -f prompt.txt --tag my-tag -o json 2>&1 | head -5
Tagged plan yhqr1xcswwc2j as "stderr-test-before"
{
  "id": "yhqr1xcswwc2j",
  "spec": {
    "params": [
```

## Reproduce (after)

```
$ signadot plan compile -f prompt.txt --tag my-tag -o json 2>&1 | head -5
{
  "id": "r2fjrvf59lmd4",
  "spec": {
    "params": [
      {
```

## Test plan
- [x] `plan compile --tag X -o json 2>&1` produces clean JSON (no "Tagged plan..." line)
- [x] `plan compile --tag X` (default mode) still shows "Tagged plan..." on stderr
- [x] Same fix applied to `plan create` and `plan recompile`
- [x] `plan run -o json` suppresses "Created execution..." and spinner on stderr
- [x] `plan run` (default mode) still shows spinner and status messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)