### PR TITLE
Fix get-output --all --dir to include step-scoped outputs

### DIFF
--- a/internal/command/planexec/get_output.go
+++ b/internal/command/planexec/get_output.go
@@ -13,6 +13,7 @@ import (
 	"github.com/signadot/cli/internal/config"
 	"github.com/signadot/go-sdk/client"
 	planexecs "github.com/signadot/go-sdk/client/plan_executions"
+	"github.com/signadot/go-sdk/models"
 	"github.com/spf13/cobra"
 )
 
@@ -111,11 +112,15 @@ func getAllOutputs(cfg *config.PlanExecGetOutput, log io.Writer, execID string) 
 		return err
 	}
 
-	outputs := resp.Payload.Status.Outputs
-	if len(outputs) == 0 {
+	// Reuse collectAllOutputs to gather plan-level and step-level outputs.
+	all := collectAllOutputs(resp.Payload)
+	if len(all) == 0 {
 		fmt.Fprintln(log, "No outputs.")
 		return nil
 	}
+
+	// Build a metadata lookup from the raw response for sidecar export.
+	metadataMap := buildMetadataMap(resp.Payload)
 
 	if err := os.MkdirAll(cfg.Dir, 0o755); err != nil {
 		return err
@@ -129,37 +134,86 @@ func getAllOutputs(cfg *config.PlanExecGetOutput, log io.Writer, execID string) 
 
 	return cfg.APIClientWithCustomTransport(transportCfg,
 		func(c *client.SignadotAPI) error {
-			for _, o := range outputs {
-				outPath := filepath.Join(cfg.Dir, o.Name)
+			for _, o := range all {
+				// Determine file path: plan-level → <dir>/<name>, step-level → <dir>/<step>/<name>.
+				var outPath string
+				if o.Step != "" {
+					stepDir := filepath.Join(cfg.Dir, o.Step)
+					if err := os.MkdirAll(stepDir, 0o755); err != nil {
+						return fmt.Errorf("creating %s: %w", stepDir, err)
+					}
+					outPath = filepath.Join(stepDir, o.Name)
+				} else {
+					outPath = filepath.Join(cfg.Dir, o.Name)
+				}
+
 				f, err := os.Create(outPath)
 				if err != nil {
 					return fmt.Errorf("creating %s: %w", outPath, err)
 				}
-				params := planexecs.NewGetPlanExecutionOutputParams().
-					WithTimeout(4*time.Minute).
-					WithOrgName(cfg.Org).
-					WithExecutionID(execID).
-					WithOutputName(o.Name)
-				_, _, err = c.PlanExecutions.GetPlanExecutionOutput(params, nil, f)
+
+				// Download using the appropriate API based on scope.
+				qualName := o.Name
+				if o.Scope == "step" {
+					qualName = o.Step + "/" + o.Name
+					params := planexecs.NewGetStepOutputParams().
+						WithTimeout(4*time.Minute).
+						WithOrgName(cfg.Org).
+						WithExecutionID(execID).
+						WithStepID(o.Step).
+						WithOutputName(o.Name)
+					_, _, err = c.PlanExecutions.GetStepOutput(params, nil, f)
+				} else {
+					params := planexecs.NewGetPlanExecutionOutputParams().
+						WithTimeout(4*time.Minute).
+						WithOrgName(cfg.Org).
+						WithExecutionID(execID).
+						WithOutputName(o.Name)
+					_, _, err = c.PlanExecutions.GetPlanExecutionOutput(params, nil, f)
+				}
 				f.Close()
 				if err != nil {
-					return fmt.Errorf("downloading %q: %w", o.Name, err)
+					return fmt.Errorf("downloading %q: %w", qualName, err)
 				}
 				fmt.Fprintf(log, "Exported %s\n", outPath)
 
 				// Write metadata sidecar if requested.
-				if cfg.Metadata && o.Metadata != nil {
-					metaPath := outPath + ".meta.json"
-					metaJSON, err := json.MarshalIndent(o.Metadata, "", "  ")
-					if err != nil {
-						return fmt.Errorf("marshaling metadata for %q: %w", o.Name, err)
+				if cfg.Metadata {
+					if meta := metadataMap[qualName]; meta != nil {
+						metaPath := outPath + ".meta.json"
+						metaJSON, err := json.MarshalIndent(meta, "", "  ")
+						if err != nil {
+							return fmt.Errorf("marshaling metadata for %q: %w", qualName, err)
+						}
+						if err := os.WriteFile(metaPath, metaJSON, 0o644); err != nil {
+							return fmt.Errorf("writing %s: %w", metaPath, err)
+						}
+						fmt.Fprintf(log, "Exported %s\n", metaPath)
 					}
-					if err := os.WriteFile(metaPath, metaJSON, 0o644); err != nil {
-						return fmt.Errorf("writing %s: %w", metaPath, err)
-					}
-					fmt.Fprintf(log, "Exported %s\n", metaPath)
 				}
 			}
 			return nil
 		})
+}
+
+// buildMetadataMap extracts metadata from plan-level and step-level outputs,
+// keyed by "name" (plan-level) or "step/name" (step-level).
+func buildMetadataMap(ex *models.PlanExecution) map[string]any {
+	m := map[string]any{}
+	if ex.Status == nil {
+		return m
+	}
+	for _, o := range ex.Status.Outputs {
+		if o.Metadata != nil {
+			m[o.Name] = o.Metadata
+		}
+	}
+	for _, s := range ex.Status.Steps {
+		for _, o := range s.Outputs {
+			if o.Metadata != nil {
+				m[s.ID+"/"+o.Name] = o.Metadata
+			}
+		}
+	}
+	return m
 }


### PR DESCRIPTION
## Summary
- `plan x get-output <exec-id> --all --dir` now exports both plan-level and step-level outputs
- Step-level outputs are written to `<dir>/<step-id>/<output-name>` subdirectories
- Metadata sidecars (`--metadata`) also supported for step-level outputs
- Deduplication: step outputs already promoted to plan scope are not exported twice

## Reproduce (before)

```
$ signadot plan x outputs tc78bkcfs9xdw
NAME      STEP                SCOPE   STORAGE   SIZE   READY
capture   send_http_request   step    inline    765B   true
result    check_status_code   step    inline    35B    true

$ mkdir -p /tmp/out && signadot plan x get-output tc78bkcfs9xdw --all --dir /tmp/out/
No outputs.

$ ls /tmp/out/
(empty)
```

## Reproduce (after)

```
$ mkdir -p /tmp/out && signadot plan x get-output tc78bkcfs9xdw --all --dir /tmp/out/
Exported /tmp/out/send_http_request/capture
Exported /tmp/out/check_status_code/result

$ ls -R /tmp/out/
check_status_code
send_http_request

/tmp/out/check_status_code:
result

/tmp/out/send_http_request:
capture

$ cat /tmp/out/check_status_code/result
{"check": "Verify HTTP Status Code"}
```

## Test plan
- [x] `--all --dir` exports step-scoped outputs into `<dir>/<step>/<name>` subdirectories
- [x] `--all --dir --metadata` writes `.meta.json` sidecar files for step outputs when metadata exists
- [x] Plan-level outputs still export correctly (to `<dir>/<name>`)
- [x] Step outputs already promoted to plan scope are not duplicated
- [x] "No outputs." only shown when truly no outputs exist at any scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)