### PR TITLE
Add hidden planrunnergroup CLI command

### DIFF
--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -17,6 +17,7 @@ import (
 	"github.com/signadot/cli/internal/command/logs"
 	"github.com/signadot/cli/internal/command/mcp"
 	"github.com/signadot/cli/internal/command/plan"
+	"github.com/signadot/cli/internal/command/planrunnergroup"
 	"github.com/signadot/cli/internal/command/resourceplugin"
 	"github.com/signadot/cli/internal/command/routegroup"
 	"github.com/signadot/cli/internal/command/sandbox"
@@ -63,6 +64,7 @@ func New() *cobra.Command {
 
 		// hidden commands
 		hostedtest.New(cfg),
+		planrunnergroup.New(cfg),
 	)
 
 	return cmd

--- a/internal/command/planrunnergroup/apply.go
+++ b/internal/command/planrunnergroup/apply.go
@@ -1,0 +1,70 @@
+package planrunnergroup
+
+import (
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/signadot/cli/internal/config"
+	"github.com/signadot/cli/internal/print"
+	planrunnergroups "github.com/signadot/go-sdk/client/plan_runner_groups"
+	"github.com/signadot/go-sdk/models"
+	"github.com/spf13/cobra"
+)
+
+func newApply(prg *config.PlanRunnerGroup) *cobra.Command {
+	cfg := &config.PlanRunnerGroupApply{PlanRunnerGroup: prg}
+
+	cmd := &cobra.Command{
+		Use:   "apply -f FILENAME [ --set var1=val1 --set var2=val2 ... ]",
+		Short: "Create or update a plan runner group",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return apply(cfg, cmd.OutOrStdout(), cmd.ErrOrStderr())
+		},
+	}
+
+	cfg.AddFlags(cmd)
+
+	return cmd
+}
+
+func apply(cfg *config.PlanRunnerGroupApply, out, log io.Writer) error {
+	if err := cfg.InitAPIConfig(); err != nil {
+		return err
+	}
+	if cfg.Filename == "" {
+		return errors.New("must specify plan runner group request file with '-f' flag")
+	}
+	req, err := loadPlanRunnerGroup(cfg.Filename, cfg.TemplateVals, false)
+	if err != nil {
+		return err
+	}
+
+	params := planrunnergroups.NewApplyPlanrunnergroupParams().
+		WithOrgName(cfg.Org).
+		WithPlanRunnerGroupName(req.Name).
+		WithData(req)
+
+	result, err := cfg.Client.PlanRunnerGroups.ApplyPlanrunnergroup(params, nil)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(log, "Applied plan runner group %q\n\n", req.Name)
+
+	return writeApplyOutput(cfg, out, result.Payload)
+}
+
+func writeApplyOutput(cfg *config.PlanRunnerGroupApply, out io.Writer, resp *models.PlanRunnerGroup) error {
+	switch cfg.OutputFormat {
+	case config.OutputFormatDefault:
+		return nil
+	case config.OutputFormatJSON:
+		return print.RawJSON(out, resp)
+	case config.OutputFormatYAML:
+		return print.RawYAML(out, resp)
+	default:
+		return fmt.Errorf("unsupported output format: %q", cfg.OutputFormat)
+	}
+}

--- a/internal/command/planrunnergroup/command.go
+++ b/internal/command/planrunnergroup/command.go
@@ -1,0 +1,27 @@
+package planrunnergroup
+
+import (
+	"github.com/signadot/cli/internal/config"
+	"github.com/spf13/cobra"
+)
+
+func New(api *config.API) *cobra.Command {
+	cfg := &config.PlanRunnerGroup{API: api}
+
+	cmd := &cobra.Command{
+		Use:     "planrunnergroup",
+		Short:   "Manage plan runner groups",
+		Aliases: []string{"prg"},
+		Hidden:  true,
+	}
+
+	// Subcommands
+	cmd.AddCommand(
+		newGet(cfg),
+		newList(cfg),
+		newApply(cfg),
+		newDelete(cfg),
+	)
+
+	return cmd
+}

--- a/internal/command/planrunnergroup/delete.go
+++ b/internal/command/planrunnergroup/delete.go
@@ -1,0 +1,69 @@
+package planrunnergroup
+
+import (
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/signadot/cli/internal/config"
+	planrunnergroups "github.com/signadot/go-sdk/client/plan_runner_groups"
+	"github.com/spf13/cobra"
+)
+
+func newDelete(prg *config.PlanRunnerGroup) *cobra.Command {
+	cfg := &config.PlanRunnerGroupDelete{PlanRunnerGroup: prg}
+
+	cmd := &cobra.Command{
+		Use:   "delete { NAME | -f FILENAME [ --set var1=val1 --set var2=val2 ... ] }",
+		Short: "Delete plan runner group",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return prgDelete(cfg, cmd.ErrOrStderr(), args)
+		},
+	}
+
+	cfg.AddFlags(cmd)
+
+	return cmd
+}
+
+func prgDelete(cfg *config.PlanRunnerGroupDelete, log io.Writer, args []string) error {
+	if err := cfg.InitAPIConfig(); err != nil {
+		return err
+	}
+	var name string
+	if cfg.Filename == "" {
+		if len(args) == 0 {
+			return errors.New("must specify filename (-f) or plan runner group name")
+		}
+		if len(cfg.TemplateVals) != 0 {
+			return errors.New("must specify filename (-f) to use --set")
+		}
+		name = args[0]
+	} else {
+		if len(args) != 0 {
+			return errors.New("must not provide args when filename (-f) specified")
+		}
+		prg, err := loadPlanRunnerGroup(cfg.Filename, cfg.TemplateVals, true)
+		if err != nil {
+			return err
+		}
+		name = prg.Name
+	}
+
+	if name == "" {
+		return errors.New("plan runner group name is required")
+	}
+
+	params := planrunnergroups.NewDeletePlanrunnergroupParams().
+		WithOrgName(cfg.Org).
+		WithPlanRunnerGroupName(name)
+	_, err := cfg.Client.PlanRunnerGroups.DeletePlanrunnergroup(params, nil)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(log, "Deleted plan runner group %q.\n\n", name)
+
+	return nil
+}

--- a/internal/command/planrunnergroup/get.go
+++ b/internal/command/planrunnergroup/get.go
@@ -1,0 +1,50 @@
+package planrunnergroup
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/signadot/cli/internal/config"
+	"github.com/signadot/cli/internal/print"
+	planrunnergroups "github.com/signadot/go-sdk/client/plan_runner_groups"
+	"github.com/spf13/cobra"
+)
+
+func newGet(prg *config.PlanRunnerGroup) *cobra.Command {
+	cfg := &config.PlanRunnerGroupGet{PlanRunnerGroup: prg}
+
+	cmd := &cobra.Command{
+		Use:   "get NAME",
+		Short: "Get plan runner group",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return get(cfg, cmd.OutOrStdout(), args[0])
+		},
+	}
+
+	return cmd
+}
+
+func get(cfg *config.PlanRunnerGroupGet, out io.Writer, name string) error {
+	if err := cfg.InitAPIConfig(); err != nil {
+		return err
+	}
+	params := planrunnergroups.NewGetPlanrunnergroupParams().
+		WithOrgName(cfg.Org).
+		WithPlanRunnerGroupName(name)
+	resp, err := cfg.Client.PlanRunnerGroups.GetPlanrunnergroup(params, nil)
+	if err != nil {
+		return err
+	}
+
+	switch cfg.OutputFormat {
+	case config.OutputFormatDefault:
+		return printPlanRunnerGroupDetails(out, resp.Payload)
+	case config.OutputFormatJSON:
+		return print.RawJSON(out, resp.Payload)
+	case config.OutputFormatYAML:
+		return print.RawYAML(out, resp.Payload)
+	default:
+		return fmt.Errorf("unsupported output format: %q", cfg.OutputFormat)
+	}
+}

--- a/internal/command/planrunnergroup/list.go
+++ b/internal/command/planrunnergroup/list.go
@@ -1,0 +1,48 @@
+package planrunnergroup
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/signadot/cli/internal/config"
+	"github.com/signadot/cli/internal/print"
+	planrunnergroups "github.com/signadot/go-sdk/client/plan_runner_groups"
+	"github.com/spf13/cobra"
+)
+
+func newList(prg *config.PlanRunnerGroup) *cobra.Command {
+	cfg := &config.PlanRunnerGroupList{PlanRunnerGroup: prg}
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List plan runner groups",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return list(cfg, cmd.OutOrStdout())
+		},
+	}
+
+	return cmd
+}
+
+func list(cfg *config.PlanRunnerGroupList, out io.Writer) error {
+	if err := cfg.InitAPIConfig(); err != nil {
+		return err
+	}
+	resp, err := cfg.Client.PlanRunnerGroups.ListPlanrunnergroup(
+		planrunnergroups.NewListPlanrunnergroupParams().WithOrgName(cfg.Org), nil)
+	if err != nil {
+		return err
+	}
+
+	switch cfg.OutputFormat {
+	case config.OutputFormatDefault:
+		return printPlanRunnerGroupTable(out, resp.Payload)
+	case config.OutputFormatJSON:
+		return print.RawJSON(out, resp.Payload)
+	case config.OutputFormatYAML:
+		return print.RawYAML(out, resp.Payload)
+	default:
+		return fmt.Errorf("unsupported output format: %q", cfg.OutputFormat)
+	}
+}

--- a/internal/command/planrunnergroup/printers.go
+++ b/internal/command/planrunnergroup/printers.go
@@ -1,0 +1,61 @@
+package planrunnergroup
+
+import (
+	"fmt"
+	"io"
+	"text/tabwriter"
+	"time"
+
+	"github.com/signadot/cli/internal/sdtab"
+	"github.com/signadot/cli/internal/utils"
+	"github.com/signadot/go-sdk/models"
+	"github.com/xeonx/timeago"
+)
+
+type planRunnerGroupRow struct {
+	Name    string `sdtab:"NAME"`
+	Cluster string `sdtab:"CLUSTER"`
+	Created string `sdtab:"CREATED"`
+	Status  string `sdtab:"STATUS"`
+}
+
+func printPlanRunnerGroupTable(out io.Writer, prgs []*models.PlanRunnerGroup) error {
+	t := sdtab.New[planRunnerGroupRow](out)
+	t.AddHeader()
+	for _, prg := range prgs {
+		createdAt, err := time.Parse(time.RFC3339, prg.CreatedAt)
+		if err != nil {
+			return err
+		}
+
+		t.AddRow(planRunnerGroupRow{
+			Name:    prg.Name,
+			Cluster: prg.Spec.Cluster,
+			Created: timeago.NoMax(timeago.English).Format(createdAt),
+			Status:  readiness(prg),
+		})
+	}
+	return t.Flush()
+}
+
+func printPlanRunnerGroupDetails(out io.Writer, prg *models.PlanRunnerGroup) error {
+	tw := tabwriter.NewWriter(out, 0, 0, 3, ' ', 0)
+
+	fmt.Fprintf(tw, "Name:\t%s\n", prg.Name)
+	fmt.Fprintf(tw, "Cluster:\t%s\n", prg.Spec.Cluster)
+	fmt.Fprintf(tw, "Created:\t%s\n", utils.FormatTimestamp(prg.CreatedAt))
+	fmt.Fprintf(tw, "Status:\t%s\n", readiness(prg))
+
+	return tw.Flush()
+}
+
+func readiness(prg *models.PlanRunnerGroup) string {
+	if prg.DeletedAt != "" {
+		return "draining"
+	}
+	if prg.Status == nil || prg.Status.Pods == nil {
+		return "-"
+	}
+	return fmt.Sprintf("%d/%d pods ready",
+		prg.Status.Pods.Ready, prg.Status.Pods.Ready+prg.Status.Pods.NotReady)
+}

--- a/internal/command/planrunnergroup/subst.go
+++ b/internal/command/planrunnergroup/subst.go
@@ -1,0 +1,37 @@
+package planrunnergroup
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/signadot/cli/internal/config"
+	"github.com/signadot/cli/internal/jsonexact"
+	"github.com/signadot/cli/internal/utils"
+	"github.com/signadot/go-sdk/models"
+)
+
+func loadPlanRunnerGroup(file string, tplVals config.TemplateVals, forDelete bool) (*models.PlanRunnerGroup, error) {
+	template, err := utils.LoadUnstructuredTemplate(file, tplVals, forDelete)
+	if err != nil {
+		return nil, err
+	}
+	return unstructuredToPlanRunnerGroup(template)
+}
+
+func unstructuredToPlanRunnerGroup(un any) (*models.PlanRunnerGroup, error) {
+	name, spec, err := utils.UnstructuredToNameAndSpec(un)
+	if err != nil {
+		return nil, err
+	}
+	d, err := json.Marshal(spec)
+	if err != nil {
+		return nil, err
+	}
+	prg := &models.PlanRunnerGroup{Name: name}
+	if err := jsonexact.Unmarshal(d, &prg.Spec); err != nil {
+		return nil, fmt.Errorf("couldn't parse YAML plan runner group definition - %s",
+			strings.TrimPrefix(err.Error(), "json: "))
+	}
+	return prg, nil
+}

--- a/internal/config/planrunnergroup.go
+++ b/internal/config/planrunnergroup.go
@@ -1,0 +1,44 @@
+package config
+
+import (
+	"github.com/spf13/cobra"
+)
+
+type PlanRunnerGroup struct {
+	*API
+}
+
+type PlanRunnerGroupApply struct {
+	*PlanRunnerGroup
+
+	// Flags
+	Filename     string
+	TemplateVals TemplateVals
+}
+
+func (c *PlanRunnerGroupApply) AddFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(&c.Filename, "filename", "f", "", "YAML or JSON file containing the plan runner group definition")
+	cmd.MarkFlagRequired("filename")
+	cmd.Flags().Var(&c.TemplateVals, "set", "--set var=val")
+}
+
+type PlanRunnerGroupDelete struct {
+	*PlanRunnerGroup
+
+	// Flags
+	Filename     string
+	TemplateVals TemplateVals
+}
+
+func (c *PlanRunnerGroupDelete) AddFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(&c.Filename, "filename", "f", "", "optional YAML or JSON file containing the plan runner group definition")
+	cmd.Flags().Var(&c.TemplateVals, "set", "--set var=val")
+}
+
+type PlanRunnerGroupGet struct {
+	*PlanRunnerGroup
+}
+
+type PlanRunnerGroupList struct {
+	*PlanRunnerGroup
+}


### PR DESCRIPTION

## Summary
- Part of e2e effort.
- Adds `signadot planrunnergroup` (alias `prg`) as a hidden CLI command with apply/get/list/delete subcommands
- Modeled 1:1 after the existing `jobrunnergroup` command, using the go-sdk `plan_runner_groups` client
- Needed for plan e2e test infrastructure (PRG setup/teardown)

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `signadot planrunnergroup --help` shows subcommands
- [x] `signadot prg --help` alias works
- [x] Command hidden from top-level `signadot --help`

🤖 Generated with [Claude Code](https://claude.com/claude-code)