### PR TITLE
plan x get-output: sidecars by default with server Content-Type

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/nsf/jsondiff v0.0.0-20210926074059-1e845ec5d249
 	github.com/oklog/run v1.1.0
 	github.com/panta/machineid v1.0.2
-	github.com/signadot/go-sdk v0.3.8-0.20260410083957-d025f4d8f72c
+	github.com/signadot/go-sdk v0.3.8-0.20260414122927-170febfcff95
 	github.com/signadot/libconnect v0.1.1-0.20260224205539-f894c2d0a57e
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/viper v1.11.0

--- a/go.sum
+++ b/go.sum
@@ -424,6 +424,8 @@ github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
 github.com/signadot/go-sdk v0.3.8-0.20260410083957-d025f4d8f72c h1:aI/nG6B1T6WqdbIplqyo3BDfMa/dawJnwPcpq0ygDvY=
 github.com/signadot/go-sdk v0.3.8-0.20260410083957-d025f4d8f72c/go.mod h1:dOoiOHHKM3oOEVD/WxAIq3Cv37032VfXvQO1IU7jJFk=
+github.com/signadot/go-sdk v0.3.8-0.20260414122927-170febfcff95 h1:Yc0tkczAm+vAb1qSk97yasya8gbpH7tNQxS9DajpBqw=
+github.com/signadot/go-sdk v0.3.8-0.20260414122927-170febfcff95/go.mod h1:dOoiOHHKM3oOEVD/WxAIq3Cv37032VfXvQO1IU7jJFk=
 github.com/signadot/libconnect v0.1.1-0.20260224205539-f894c2d0a57e h1:NiYn5S3cMIhsGh3RzBgRg9NzLDG5qEP7uhSJKtwW7oc=
 github.com/signadot/libconnect v0.1.1-0.20260224205539-f894c2d0a57e/go.mod h1:cAsgAummH9Q9DrLQ7+S3mqrBv/+ZYKVSEXjR/WfoUJM=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=

--- a/internal/command/planexec/get_output.go
+++ b/internal/command/planexec/get_output.go
@@ -31,7 +31,7 @@ Single output:
 
 Bulk export:
   signadot plan x get-output <exec-id> --all --dir ./outputs/
-  signadot plan x get-output <exec-id> --all --dir ./outputs/ --metadata`,
+  signadot plan x get-output <exec-id> --all --dir ./outputs/ --metadata=false  # skip sidecars`,
 		Args: cobra.RangeArgs(1, 2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if cfg.All {
@@ -52,7 +52,8 @@ Bulk export:
 
 	cmd.Flags().BoolVar(&cfg.All, "all", false, "export all outputs")
 	cmd.Flags().StringVar(&cfg.Dir, "dir", "", "directory to export outputs to (requires --all)")
-	cmd.Flags().BoolVar(&cfg.Metadata, "metadata", false, "write metadata sidecar JSON files (requires --all)")
+	cmd.Flags().BoolVar(&cfg.Metadata, "metadata", true,
+		"write .meta.json sidecar files alongside each exported output (requires --all; pass --metadata=false to disable)")
 
 	return cmd
 }
@@ -119,7 +120,10 @@ func getAllOutputs(cfg *config.PlanExecGetOutput, log io.Writer, execID string) 
 		return nil
 	}
 
-	// Build a metadata lookup from the raw response for sidecar export.
+	// Build a metadata lookup keyed by qualified name (<name> for plan
+	// outputs, <step>/<name> for step outputs). Outputs without any
+	// explicit metadata map to nil entries — sidecars are still written
+	// for them using the derived fields alone.
 	metadataMap := buildMetadataMap(resp.Payload)
 
 	if err := os.MkdirAll(cfg.Dir, 0o755); err != nil {
@@ -153,7 +157,12 @@ func getAllOutputs(cfg *config.PlanExecGetOutput, log io.Writer, execID string) 
 				}
 
 				// Download using the appropriate API based on scope.
+				// Capture Content-Type from the response so the sidecar
+				// can record the server-supplied value rather than a
+				// re-derived one (keeps the server's
+				// plans.ResolveContentType as the single source of truth).
 				qualName := o.Name
+				var contentType string
 				if o.Scope == "step" {
 					qualName = o.Step + "/" + o.Name
 					params := planexecs.NewGetStepOutputParams().
@@ -162,14 +171,28 @@ func getAllOutputs(cfg *config.PlanExecGetOutput, log io.Writer, execID string) 
 						WithExecutionID(execID).
 						WithStepID(o.Step).
 						WithOutputName(o.Name)
-					_, _, err = c.PlanExecutions.GetStepOutput(params, nil, f)
+					ok, partial, getErr := c.PlanExecutions.GetStepOutput(params, nil, f)
+					err = getErr
+					switch {
+					case ok != nil:
+						contentType = ok.ContentType
+					case partial != nil:
+						contentType = partial.ContentType
+					}
 				} else {
 					params := planexecs.NewGetPlanExecutionOutputParams().
 						WithTimeout(4*time.Minute).
 						WithOrgName(cfg.Org).
 						WithExecutionID(execID).
 						WithOutputName(o.Name)
-					_, _, err = c.PlanExecutions.GetPlanExecutionOutput(params, nil, f)
+					ok, partial, getErr := c.PlanExecutions.GetPlanExecutionOutput(params, nil, f)
+					err = getErr
+					switch {
+					case ok != nil:
+						contentType = ok.ContentType
+					case partial != nil:
+						contentType = partial.ContentType
+					}
 				}
 				f.Close()
 				if err != nil {
@@ -177,19 +200,27 @@ func getAllOutputs(cfg *config.PlanExecGetOutput, log io.Writer, execID string) 
 				}
 				fmt.Fprintf(log, "Exported %s\n", outPath)
 
-				// Write metadata sidecar if requested.
+				// Write sidecar. --metadata is on by default; pass
+				// --metadata=false to disable. The sidecar is always
+				// emitted (regardless of whether the output carries
+				// explicit metadata) so the derived fields — scope,
+				// step, inline vs artifact, size, ready, contentType —
+				// are visible to the reader without another round-trip.
 				if cfg.Metadata {
-					if meta := metadataMap[qualName]; meta != nil {
-						metaPath := outPath + ".meta.json"
-						metaJSON, err := json.MarshalIndent(meta, "", "  ")
-						if err != nil {
-							return fmt.Errorf("marshaling metadata for %q: %w", qualName, err)
-						}
-						if err := os.WriteFile(metaPath, metaJSON, 0o644); err != nil {
-							return fmt.Errorf("writing %s: %w", metaPath, err)
-						}
-						fmt.Fprintf(log, "Exported %s\n", metaPath)
+					sidecar := outputSidecar{
+						allOutput:   o,
+						ContentType: contentType,
+						Metadata:    metadataMap[qualName],
 					}
+					metaPath := outPath + ".meta.json"
+					metaJSON, err := json.MarshalIndent(sidecar, "", "  ")
+					if err != nil {
+						return fmt.Errorf("marshaling sidecar for %q: %w", qualName, err)
+					}
+					if err := os.WriteFile(metaPath, metaJSON, 0o644); err != nil {
+						return fmt.Errorf("writing %s: %w", metaPath, err)
+					}
+					fmt.Fprintf(log, "Exported %s\n", metaPath)
 				}
 			}
 			return nil
@@ -198,19 +229,24 @@ func getAllOutputs(cfg *config.PlanExecGetOutput, log io.Writer, execID string) 
 
 // buildMetadataMap extracts metadata from plan-level and step-level outputs,
 // keyed by "name" (plan-level) or "step/name" (step-level).
-func buildMetadataMap(ex *models.PlanExecution) map[string]any {
-	m := map[string]any{}
+// buildMetadataMap returns each output's explicit metadata keyed by
+// qualified name: "<name>" for plan-level outputs, "<step>/<name>" for
+// step-level outputs. Outputs that carry no explicit metadata are
+// absent from the map (so a lookup returns a nil map, which is the
+// correct omitempty signal for the sidecar).
+func buildMetadataMap(ex *models.PlanExecution) map[string]map[string]string {
+	m := map[string]map[string]string{}
 	if ex.Status == nil {
 		return m
 	}
 	for _, o := range ex.Status.Outputs {
-		if o.Metadata != nil {
+		if len(o.Metadata) > 0 {
 			m[o.Name] = o.Metadata
 		}
 	}
 	for _, s := range ex.Status.Steps {
 		for _, o := range s.Outputs {
-			if o.Metadata != nil {
+			if len(o.Metadata) > 0 {
 				m[s.ID+"/"+o.Name] = o.Metadata
 			}
 		}

--- a/internal/command/planexec/outputs.go
+++ b/internal/command/planexec/outputs.go
@@ -28,13 +28,30 @@ func newOutputs(exec *config.PlanExecution) *cobra.Command {
 }
 
 // allOutput unifies plan-level and step-level outputs for display.
+// Size has no omitempty so a 0-byte output (e.g. a silent stdout)
+// shows "size": 0 in sidecars rather than being elided — a missing
+// field would be ambiguous with "size not reported".
 type allOutput struct {
 	Name  string `json:"name"`
-	Step  string `json:"step"`
+	Step  string `json:"step,omitempty"`
 	Scope string `json:"scope"` // "plan" or "step"
 	Type  string `json:"type"`  // "inline" or "artifact"
-	Size  int64  `json:"size,omitempty"`
+	Size  int64  `json:"size"`
 	Ready *bool  `json:"ready,omitempty"`
+}
+
+// outputSidecar is the .meta.json content written alongside each
+// exported output under --all --metadata. It combines derived fields
+// (name, scope, step, type, size, ready) with the server-supplied
+// Content-Type and any explicit metadata the step or plan declared,
+// so the reader can tell what an exported file is without opening it.
+type outputSidecar struct {
+	allOutput
+	// ContentType is the Content-Type header the apiserver returned
+	// when downloading this output. Omitted when absent (e.g. drill
+	// paths that don't set it, or older servers).
+	ContentType string            `json:"contentType,omitempty"`
+	Metadata    map[string]string `json:"metadata,omitempty"`
 }
 
 func listOutputs(cfg *config.PlanExecOutputs, out io.Writer, execID string) error {


### PR DESCRIPTION
Depends on https://github.com/signadot/signadot/pull/6884

## Summary

- Make \`--metadata\` default true for \`plan x get-output --all\` so sidecars ship with every bulk export.
- Emit a sidecar for every output, including ones with no explicit metadata — previously \`stdout\`/\`stderr\`/\`exitCode\` silently got no sidecar because \`buildMetadataMap\` only kept entries with non-nil \`Metadata\`, so the user had no way to tell what an exported file was without opening it.
- Record the server-supplied \`Content-Type\` header on the sidecar (keeps \`plans.ResolveContentType\` on the server as the single source of truth — no client-side re-derivation). Relies on the matching \`@Header\` swagger annotation on the apiserver; see signadot/signadot#6884.
- Drop \`omitempty\` on \`Size\` so 0-byte outputs show \`size: 0\` rather than an elided field (which was ambiguous with "size not reported").
- Bump go-sdk to \`170febfc\` to pick up the new \`ContentType\` field on \`GetStepOutputOK\` / \`GetPlanExecutionOutputOK\`.

## Example sidecar

\`\`\`json
{
  "name": "stdout",
  "step": "sidecar_test",
  "scope": "step",
  "type": "inline",
  "size": 0,
  "ready": true,
  "contentType": "text/plain; charset=utf-8"
}
\`\`\`

## Test plan

- [x] \`go build ./...\`
- [x] Manual against a live minikube: \`signadot plan x get-output <execID> --all --dir /tmp/out\` produces 4 outputs × 2 files (4 sidecars), sidecars contain \`contentType\` matching the server's header.
- [x] Verify \`--metadata=false\` still suppresses sidecars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)