### PR TITLE
plan x get: surface input resolution status

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/nsf/jsondiff v0.0.0-20210926074059-1e845ec5d249
 	github.com/oklog/run v1.1.0
 	github.com/panta/machineid v1.0.2
-	github.com/signadot/go-sdk v0.3.8-0.20260505171357-a02f1a78bde4
+	github.com/signadot/go-sdk v0.3.8-0.20260505200838-3bae35b0d0d8
 	github.com/signadot/libconnect v0.1.1-0.20260424105947-336dce43da75
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/viper v1.11.0

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834
 	github.com/docker/go-units v0.5.0
 	github.com/go-git/go-git/v5 v5.18.0
-	github.com/go-openapi/runtime v0.29.4
+	github.com/go-openapi/runtime v0.29.5
 	github.com/go-openapi/strfmt v0.26.2
 	github.com/goccy/go-yaml v1.10.0
 	github.com/golang/protobuf v1.5.4
@@ -22,7 +22,7 @@ require (
 	github.com/nsf/jsondiff v0.0.0-20210926074059-1e845ec5d249
 	github.com/oklog/run v1.1.0
 	github.com/panta/machineid v1.0.2
-	github.com/signadot/go-sdk v0.3.8-0.20260429134502-a68ea488880a
+	github.com/signadot/go-sdk v0.3.8-0.20260505171357-a02f1a78bde4
 	github.com/signadot/libconnect v0.1.1-0.20260424105947-336dce43da75
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/viper v1.11.0

--- a/go.sum
+++ b/go.sum
@@ -178,8 +178,8 @@ github.com/go-openapi/jsonreference v0.21.5 h1:6uCGVXU/aNF13AQNggxfysJ+5ZcU4nEAe
 github.com/go-openapi/jsonreference v0.21.5/go.mod h1:u25Bw85sX4E2jzFodh1FOKMTZLcfifd1Q+iKKOUxExw=
 github.com/go-openapi/loads v0.23.3 h1:g5Xap1JfwKkUnZdn+S0L3SzBDpcTIYzZ5Qaag0YDkKQ=
 github.com/go-openapi/loads v0.23.3/go.mod h1:NOH07zLajXo8y55hom0omlHWDVVvCwBM/S+csCK8LqA=
-github.com/go-openapi/runtime v0.29.4 h1:k2lDxrGoSAJRdhFG2tONKMpkizY/4X1cciSdtzk4Jjo=
-github.com/go-openapi/runtime v0.29.4/go.mod h1:K0k/2raY6oqXJnZAgWJB2i/12QKrhUKpZcH4PfV9P18=
+github.com/go-openapi/runtime v0.29.5 h1:uc5+/TtqLIfDBTUxnF3uppoGMt+9DzonwUWsviINlrY=
+github.com/go-openapi/runtime v0.29.5/go.mod h1:D9IUbWccdYv+km8QwmAm90FZvDcQk47vP2Y7y5as/D8=
 github.com/go-openapi/spec v0.22.4 h1:4pxGjipMKu0FzFiu/DPwN3CTBRlVM2yLf/YTWorYfDQ=
 github.com/go-openapi/spec v0.22.4/go.mod h1:WQ6Ai0VPWMZgMT4XySjlRIE6GP1bGQOtEThn3gcWLtQ=
 github.com/go-openapi/strfmt v0.26.2 h1:ysjheCh4i1rmFEo2LanhELDNucNzfWTZhUDKgWWPaFM=
@@ -210,10 +210,10 @@ github.com/go-openapi/swag/typeutils v0.26.0 h1:2kdEwdiNWy+JJdOvu5MA2IIg2SylWAFu
 github.com/go-openapi/swag/typeutils v0.26.0/go.mod h1:oovDuIUvTrEHVMqWilQzKzV4YlSKgyZmFh7AlfABNVE=
 github.com/go-openapi/swag/yamlutils v0.26.0 h1:H7O8l/8NJJQ/oiReEN+oMpnGMyt8G0hl460nRZxhLMQ=
 github.com/go-openapi/swag/yamlutils v0.26.0/go.mod h1:1evKEGAtP37Pkwcc7EWMF0hedX0/x3Rkvei2wtG/TbU=
-github.com/go-openapi/testify/enable/yaml/v2 v2.4.2 h1:5zRca5jw7lzVREKCZVNBpysDNBjj74rBh0N2BGQbSR0=
-github.com/go-openapi/testify/enable/yaml/v2 v2.4.2/go.mod h1:XVevPw5hUXuV+5AkI1u1PeAm27EQVrhXTTCPAF85LmE=
-github.com/go-openapi/testify/v2 v2.4.2 h1:tiByHpvE9uHrrKjOszax7ZvKB7QOgizBWGBLuq0ePx4=
-github.com/go-openapi/testify/v2 v2.4.2/go.mod h1:SgsVHtfooshd0tublTtJ50FPKhujf47YRqauXXOUxfw=
+github.com/go-openapi/testify/enable/yaml/v2 v2.5.0 h1:3hZD1fwydvCx/cc1R2uYNQirHqf2s6lqpKV3FcNTURA=
+github.com/go-openapi/testify/enable/yaml/v2 v2.5.0/go.mod h1:TvDZKBH7ZbMaF3EqH2AwTvNQCmzyZq8K1agRjf1B+Nk=
+github.com/go-openapi/testify/v2 v2.5.0 h1:UOCr63aAsMIDydZbZGqo5Ev01D4eydItRbekDuZMJLw=
+github.com/go-openapi/testify/v2 v2.5.0/go.mod h1:SgsVHtfooshd0tublTtJ50FPKhujf47YRqauXXOUxfw=
 github.com/go-openapi/validate v0.25.2 h1:12NsfLAwGegqbGWr2CnvT65X/Q2USJipmJ9b7xDJZz0=
 github.com/go-openapi/validate v0.25.2/go.mod h1:Pgl1LpPPGFnZ+ys4/hTlDiRYQdI1ocKypgE+8Q8BLfY=
 github.com/go-playground/assert/v2 v2.0.1/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
@@ -452,8 +452,8 @@ github.com/segmentio/encoding v0.5.4 h1:OW1VRern8Nw6ITAtwSZ7Idrl3MXCFwXHPgqESYfv
 github.com/segmentio/encoding v0.5.4/go.mod h1:HS1ZKa3kSN32ZHVZ7ZLPLXWvOVIiZtyJnO1gPH1sKt0=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN3Uc8sB6B/s6Z4t2xvBgU1htSHuq8=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
-github.com/signadot/go-sdk v0.3.8-0.20260429134502-a68ea488880a h1:S7Yc47d3onGEGKcPUrL2gNKQGuZ2yxFyr6MxVLGYHPE=
-github.com/signadot/go-sdk v0.3.8-0.20260429134502-a68ea488880a/go.mod h1:FgM6/qeQ7IdRh+hGdqWOY0ShCXkRN2bBPsWX6bILVDI=
+github.com/signadot/go-sdk v0.3.8-0.20260505171357-a02f1a78bde4 h1:egJ0Kuj7ZAHA8td1XQPiOIB6Xaj0JsjGTp/ptCUDBqU=
+github.com/signadot/go-sdk v0.3.8-0.20260505171357-a02f1a78bde4/go.mod h1:8CfvBQ/AQ3LPruaQZoflmpBjoZTwXfhBt2OtS1eet+Q=
 github.com/signadot/libconnect v0.1.1-0.20260424105947-336dce43da75 h1:LZJrEqJeSb0CGsENOAQsvDeEO2YyMY1/ir2Nz4apvbI=
 github.com/signadot/libconnect v0.1.1-0.20260424105947-336dce43da75/go.mod h1:cAsgAummH9Q9DrLQ7+S3mqrBv/+ZYKVSEXjR/WfoUJM=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=

--- a/go.sum
+++ b/go.sum
@@ -454,6 +454,8 @@ github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
 github.com/signadot/go-sdk v0.3.8-0.20260505171357-a02f1a78bde4 h1:egJ0Kuj7ZAHA8td1XQPiOIB6Xaj0JsjGTp/ptCUDBqU=
 github.com/signadot/go-sdk v0.3.8-0.20260505171357-a02f1a78bde4/go.mod h1:8CfvBQ/AQ3LPruaQZoflmpBjoZTwXfhBt2OtS1eet+Q=
+github.com/signadot/go-sdk v0.3.8-0.20260505200838-3bae35b0d0d8 h1:KFayX3D9o1XaDA8JNIngOVEDc0t35Y5pERsAn3Tti8A=
+github.com/signadot/go-sdk v0.3.8-0.20260505200838-3bae35b0d0d8/go.mod h1:8CfvBQ/AQ3LPruaQZoflmpBjoZTwXfhBt2OtS1eet+Q=
 github.com/signadot/libconnect v0.1.1-0.20260424105947-336dce43da75 h1:LZJrEqJeSb0CGsENOAQsvDeEO2YyMY1/ir2Nz4apvbI=
 github.com/signadot/libconnect v0.1.1-0.20260424105947-336dce43da75/go.mod h1:cAsgAummH9Q9DrLQ7+S3mqrBv/+ZYKVSEXjR/WfoUJM=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=

--- a/go.sum
+++ b/go.sum
@@ -452,8 +452,6 @@ github.com/segmentio/encoding v0.5.4 h1:OW1VRern8Nw6ITAtwSZ7Idrl3MXCFwXHPgqESYfv
 github.com/segmentio/encoding v0.5.4/go.mod h1:HS1ZKa3kSN32ZHVZ7ZLPLXWvOVIiZtyJnO1gPH1sKt0=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN3Uc8sB6B/s6Z4t2xvBgU1htSHuq8=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
-github.com/signadot/go-sdk v0.3.8-0.20260505171357-a02f1a78bde4 h1:egJ0Kuj7ZAHA8td1XQPiOIB6Xaj0JsjGTp/ptCUDBqU=
-github.com/signadot/go-sdk v0.3.8-0.20260505171357-a02f1a78bde4/go.mod h1:8CfvBQ/AQ3LPruaQZoflmpBjoZTwXfhBt2OtS1eet+Q=
 github.com/signadot/go-sdk v0.3.8-0.20260505200838-3bae35b0d0d8 h1:KFayX3D9o1XaDA8JNIngOVEDc0t35Y5pERsAn3Tti8A=
 github.com/signadot/go-sdk v0.3.8-0.20260505200838-3bae35b0d0d8/go.mod h1:8CfvBQ/AQ3LPruaQZoflmpBjoZTwXfhBt2OtS1eet+Q=
 github.com/signadot/libconnect v0.1.1-0.20260424105947-336dce43da75 h1:LZJrEqJeSb0CGsENOAQsvDeEO2YyMY1/ir2Nz4apvbI=

--- a/internal/command/plan/compile.go
+++ b/internal/command/plan/compile.go
@@ -54,7 +54,8 @@ func compile(cfg *config.PlanCompile, out, log io.Writer) error {
 	params := sdkplans.NewCompilePlanParams().
 		WithOrgName(cfg.Org).
 		WithData(&models.PlanCompileInput{
-			Prompt: prompt,
+			Prompt:        prompt,
+			SelectionHint: cfg.SelectionHint,
 		})
 	resp, err := cfg.Client.Plans.CompilePlan(params, nil)
 	if err != nil {

--- a/internal/command/plan/printers.go
+++ b/internal/command/plan/printers.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"sort"
-	"strings"
 	"text/tabwriter"
 
 	"github.com/signadot/cli/internal/print"
@@ -35,9 +34,6 @@ func printPlanDetails(out io.Writer, p *models.RunnablePlan) error {
 			case c.Pattern != "":
 				fmt.Fprintf(tw, "Cluster:\tpattern %q\n", c.Pattern)
 			}
-		}
-		if len(p.Spec.Requires) > 0 {
-			fmt.Fprintf(tw, "Requires:\t%s\n", strings.Join(p.Spec.Requires, ", "))
 		}
 	}
 	if p.Status != nil {
@@ -136,13 +132,18 @@ func printPlanSteps(out io.Writer, steps []*models.PlanStep) {
 		}
 		fmt.Fprintf(out, "  %s\n", s.ID)
 		if s.Action != nil {
-			line := "    action: " + s.Action.ActionID
+			line := "    action: " + actionLabel(s.Action)
 			if s.Action.Revision > 0 {
 				line += fmt.Sprintf("   (revision %d)", s.Action.Revision)
 			}
 			fmt.Fprintln(out, line)
 			if img := formatImage(s.Action.Image); img != "" {
 				fmt.Fprintf(out, "    image: %s\n", img)
+			}
+			if s.Action.Timeout != "" {
+				fmt.Fprintf(out, "    timeout: %s\n", s.Action.Timeout)
+			} else if s.Action.TimeoutInputName != "" {
+				fmt.Fprintf(out, "    timeout: (from input %q)\n", s.Action.TimeoutInputName)
 			}
 		}
 		if s.Condition != "" {
@@ -248,6 +249,23 @@ func formatValue(v any) string {
 		return fmt.Sprintf("%v", v)
 	}
 	return string(b)
+}
+
+// actionLabel renders the step's action as "name (id)" when the
+// server returns both, name alone when the ID is empty, or ID alone
+// when the name isn't populated yet (older plans compiled before the
+// Name field was added).
+func actionLabel(a *models.PlanStepAction) string {
+	if a == nil {
+		return ""
+	}
+	if a.Name == "" {
+		return a.ActionID
+	}
+	if a.ActionID == "" {
+		return a.Name
+	}
+	return fmt.Sprintf("%s (%s)", a.Name, a.ActionID)
 }
 
 func formatImage(ref *models.PlanImageRef) string {

--- a/internal/command/plan/printers.go
+++ b/internal/command/plan/printers.go
@@ -1,9 +1,10 @@
 package plan
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
-	"slices"
+	"sort"
 	"strings"
 	"text/tabwriter"
 
@@ -35,22 +36,6 @@ func printPlanDetails(out io.Writer, p *models.RunnablePlan) error {
 				fmt.Fprintf(tw, "Cluster:\tpattern %q\n", c.Pattern)
 			}
 		}
-		fmt.Fprintf(tw, "Steps:\t%d\n", len(p.Spec.Steps))
-		if len(p.Spec.Params) > 0 {
-			names := make([]string, len(p.Spec.Params))
-			for i, param := range p.Spec.Params {
-				names[i] = param.Name
-			}
-			fmt.Fprintf(tw, "Params:\t%s\n", strings.Join(names, ", "))
-		}
-		if len(p.Spec.Output) > 0 {
-			outputNames := make([]string, 0, len(p.Spec.Output))
-			for k := range p.Spec.Output {
-				outputNames = append(outputNames, k)
-			}
-			slices.Sort(outputNames)
-			fmt.Fprintf(tw, "Outputs:\t%s\n", strings.Join(outputNames, ", "))
-		}
 		if len(p.Spec.Requires) > 0 {
 			fmt.Fprintf(tw, "Requires:\t%s\n", strings.Join(p.Spec.Requires, ", "))
 		}
@@ -64,6 +49,242 @@ func printPlanDetails(out io.Writer, p *models.RunnablePlan) error {
 			fmt.Fprintf(tw, "Executions:\t%d\n", p.Status.Executions)
 		}
 	}
+	if err := tw.Flush(); err != nil {
+		return err
+	}
 
-	return tw.Flush()
+	if p.Spec == nil {
+		return nil
+	}
+
+	if len(p.Spec.Params) > 0 {
+		fmt.Fprintln(out)
+		fmt.Fprintln(out, "Params:")
+		printPlanParams(out, p.Spec.Params)
+	}
+
+	if len(p.Spec.Output) > 0 {
+		fmt.Fprintln(out)
+		fmt.Fprintln(out, "Outputs:")
+		printPlanOutputs(out, p.Spec.Output)
+	}
+
+	if len(p.Spec.Steps) > 0 {
+		fmt.Fprintln(out)
+		fmt.Fprintln(out, "Steps:")
+		printPlanSteps(out, p.Spec.Steps)
+	}
+
+	return nil
+}
+
+// printPlanParams renders each declared param. Defaults render with
+// the arrow form used elsewhere; required params with no default get
+// a "(required)" tag, optional ones with no default a "(optional)".
+func printPlanParams(out io.Writer, params []*models.PlanField) {
+	maxName := 0
+	for _, p := range params {
+		if p != nil && len(p.Name) > maxName {
+			maxName = len(p.Name)
+		}
+	}
+	for _, p := range params {
+		if p == nil {
+			continue
+		}
+		var detail, via string
+		switch {
+		case p.Default != nil:
+			detail = formatValue(p.Default)
+			via = "default"
+		case p.Required:
+			via = "required"
+		default:
+			via = "optional"
+		}
+		printInputLine(out, "  ", maxName, p.Name, detail, via)
+	}
+}
+
+func printPlanOutputs(out io.Writer, outputs map[string]string) {
+	names := make([]string, 0, len(outputs))
+	for k := range outputs {
+		names = append(names, k)
+	}
+	sort.Strings(names)
+	maxName := 0
+	for _, n := range names {
+		if len(n) > maxName {
+			maxName = len(n)
+		}
+	}
+	// Plan outputs are always refs (mappings to step outputs), so we
+	// drop the trailing (ref) tag — there's no other variant to
+	// disambiguate against.
+	for _, n := range names {
+		fmt.Fprintf(out, "  %-*s   ← %s\n", maxName, n, outputs[n])
+	}
+}
+
+func printPlanSteps(out io.Writer, steps []*models.PlanStep) {
+	for i, s := range steps {
+		if s == nil {
+			continue
+		}
+		if i > 0 {
+			fmt.Fprintln(out)
+		}
+		fmt.Fprintf(out, "  %s\n", s.ID)
+		if s.Action != nil {
+			line := "    action: " + s.Action.ActionID
+			if s.Action.Revision > 0 {
+				line += fmt.Sprintf("   (revision %d)", s.Action.Revision)
+			}
+			fmt.Fprintln(out, line)
+			if img := formatImage(s.Action.Image); img != "" {
+				fmt.Fprintf(out, "    image: %s\n", img)
+			}
+		}
+		if s.Condition != "" {
+			fmt.Fprintf(out, "    when: %s\n", s.Condition)
+		}
+		printStepInputs(out, s)
+		printStepOutputs(out, s)
+	}
+}
+
+// printStepInputs lists the inputs the plan author wired for this
+// step. Values from step.Args.Values render as "set in plan"; refs
+// from step.Args.Refs render as "ref". Inputs that were neither set
+// nor wired (will fall back to defaults or be unbound at run time)
+// aren't shown here; that resolution is per-execution and lives in
+// plan x get.
+func printStepInputs(out io.Writer, s *models.PlanStep) {
+	values := paramsAsMap(stepArgsValues(s))
+	var refs map[string]string
+	if s.Args != nil {
+		refs = s.Args.Refs
+	}
+	if len(values) == 0 && len(refs) == 0 {
+		return
+	}
+
+	type wired struct {
+		name, detail, via string
+	}
+	var inputs []wired
+	for name, v := range values {
+		inputs = append(inputs, wired{name, formatValue(v), "set in plan"})
+	}
+	for name, r := range refs {
+		inputs = append(inputs, wired{name, r, "ref"})
+	}
+	sort.Slice(inputs, func(i, j int) bool { return inputs[i].name < inputs[j].name })
+
+	fmt.Fprintln(out, "    inputs:")
+	maxName := 0
+	for _, in := range inputs {
+		if len(in.name) > maxName {
+			maxName = len(in.name)
+		}
+	}
+	for _, in := range inputs {
+		printInputLine(out, "      ", maxName, in.name, in.detail, in.via)
+	}
+}
+
+// printStepOutputs lists the step's declared extra_outputs (the step-
+// level extension over the action's declared outputs) with their
+// schema summary. The action's own outputs are inherent to the action
+// and visible via signadot plan action get.
+func printStepOutputs(out io.Writer, s *models.PlanStep) {
+	if len(s.ExtraOutputs) == 0 {
+		return
+	}
+	fmt.Fprintln(out, "    outputs:")
+	maxName := 0
+	for _, o := range s.ExtraOutputs {
+		if o != nil && len(o.Name) > maxName {
+			maxName = len(o.Name)
+		}
+	}
+	for _, o := range s.ExtraOutputs {
+		if o == nil {
+			continue
+		}
+		schema := formatFieldSchema(o)
+		fmt.Fprintf(out, "      %-*s   %s\n", maxName, o.Name, schema)
+	}
+}
+
+// printInputLine emits one input row in the form
+//
+//	<indent><name padded>   ← <detail>   (<via>)
+//
+// or, when there's no detail to show:
+//
+//	<indent><name padded>   (<via>)
+func printInputLine(out io.Writer, indent string, nameWidth int, name, detail, via string) {
+	if detail == "" {
+		fmt.Fprintf(out, "%s%-*s   (%s)\n", indent, nameWidth, name, via)
+		return
+	}
+	fmt.Fprintf(out, "%s%-*s   ← %s   (%s)\n", indent, nameWidth, name, detail, via)
+}
+
+// formatValue renders a parameter value for a detail column. Strings
+// pass through as bare text; everything else round-trips through JSON
+// so objects/arrays stay copy-pasteable into a plan spec rather than
+// rendering as Go's map[a:1] / [1 2] forms.
+func formatValue(v any) string {
+	if v == nil {
+		return ""
+	}
+	if s, ok := v.(string); ok {
+		return s
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return fmt.Sprintf("%v", v)
+	}
+	return string(b)
+}
+
+func formatImage(ref *models.PlanImageRef) string {
+	if ref == nil {
+		return ""
+	}
+	if ref.Literal != "" {
+		return ref.Literal
+	}
+	if ref.InputName != "" {
+		return fmt.Sprintf("(from input %q)", ref.InputName)
+	}
+	return ""
+}
+
+func formatFieldSchema(f *models.PlanField) string {
+	if f.SchemaRef != "" {
+		return fmt.Sprintf("schema: %s", f.SchemaRef)
+	}
+	if m, ok := f.Schema.(map[string]any); ok {
+		if t, ok := m["type"].(string); ok && t != "" {
+			return fmt.Sprintf("schema: %s", t)
+		}
+	}
+	return ""
+}
+
+func stepArgsValues(s *models.PlanStep) any {
+	if s == nil || s.Args == nil {
+		return nil
+	}
+	return s.Args.Values
+}
+
+func paramsAsMap(v any) map[string]any {
+	if m, ok := v.(map[string]any); ok {
+		return m
+	}
+	return nil
 }

--- a/internal/command/plan/printers.go
+++ b/internal/command/plan/printers.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"sort"
+	"strings"
 	"text/tabwriter"
 
 	"github.com/signadot/cli/internal/print"
@@ -55,20 +56,20 @@ func printPlanDetails(out io.Writer, p *models.RunnablePlan) error {
 
 	if len(p.Spec.Params) > 0 {
 		fmt.Fprintln(out)
-		fmt.Fprintln(out, "Params:")
+		fmt.Fprintln(out, "Inputs:")
 		printPlanParams(out, p.Spec.Params)
-	}
-
-	if len(p.Spec.Output) > 0 {
-		fmt.Fprintln(out)
-		fmt.Fprintln(out, "Outputs:")
-		printPlanOutputs(out, p.Spec.Output)
 	}
 
 	if len(p.Spec.Steps) > 0 {
 		fmt.Fprintln(out)
 		fmt.Fprintln(out, "Steps:")
 		printPlanSteps(out, p.Spec.Steps)
+	}
+
+	if len(p.Spec.Output) > 0 {
+		fmt.Fprintln(out)
+		fmt.Fprintln(out, "Outputs:")
+		printPlanOutputs(out, p.Spec.Output)
 	}
 
 	return nil
@@ -236,19 +237,46 @@ func printInputLine(out io.Writer, indent string, nameWidth int, name, detail, v
 // formatValue renders a parameter value for a detail column. Strings
 // pass through as bare text; everything else round-trips through JSON
 // so objects/arrays stay copy-pasteable into a plan spec rather than
-// rendering as Go's map[a:1] / [1 2] forms.
+// rendering as Go's map[a:1] / [1 2] forms. Multi-line and very long
+// values are summarised so they don't break the inline arrow form;
+// users who want the full value can use -o yaml.
 func formatValue(v any) string {
 	if v == nil {
 		return ""
 	}
+	var raw string
 	if s, ok := v.(string); ok {
-		return s
+		raw = s
+	} else {
+		b, err := json.Marshal(v)
+		if err != nil {
+			return fmt.Sprintf("%v", v)
+		}
+		raw = string(b)
 	}
-	b, err := json.Marshal(v)
-	if err != nil {
-		return fmt.Sprintf("%v", v)
+	return truncateForDisplay(raw)
+}
+
+// maxValueDisplay caps single-line value rendering.
+const maxValueDisplay = 80
+
+// truncateForDisplay collapses a value into a single line suitable
+// for the inline arrow form. Multi-line values are reduced to the
+// first line + a (N lines) marker; over-long single lines get a
+// trailing ellipsis.
+func truncateForDisplay(s string) string {
+	trimmed := strings.TrimRight(s, "\n")
+	if firstLine, _, multiline := strings.Cut(trimmed, "\n"); multiline {
+		nLines := strings.Count(trimmed, "\n") + 1
+		if len(firstLine) > maxValueDisplay {
+			firstLine = firstLine[:maxValueDisplay]
+		}
+		return fmt.Sprintf("%s… (%d lines)", firstLine, nLines)
 	}
-	return string(b)
+	if len(trimmed) > maxValueDisplay {
+		return trimmed[:maxValueDisplay] + "…"
+	}
+	return trimmed
 }
 
 // actionLabel renders the step's action as "name (id)" when the

--- a/internal/command/plan/printers.go
+++ b/internal/command/plan/printers.go
@@ -1,13 +1,12 @@
 package plan
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 	"sort"
-	"strings"
 	"text/tabwriter"
 
+	"github.com/signadot/cli/internal/command/planshared"
 	"github.com/signadot/cli/internal/print"
 	"github.com/signadot/cli/internal/utils"
 	"github.com/signadot/go-sdk/models"
@@ -92,14 +91,14 @@ func printPlanParams(out io.Writer, params []*models.PlanField) {
 		var detail, via string
 		switch {
 		case p.Default != nil:
-			detail = formatValue(p.Default)
+			detail = planshared.FormatValue(p.Default)
 			via = "default"
 		case p.Required:
 			via = "required"
 		default:
 			via = "optional"
 		}
-		printInputLine(out, "  ", maxName, p.Name, detail, via)
+		planshared.PrintInputLine(out, "  ", maxName, p.Name, detail, via)
 	}
 }
 
@@ -133,12 +132,12 @@ func printPlanSteps(out io.Writer, steps []*models.PlanStep) {
 		}
 		fmt.Fprintf(out, "  %s\n", s.ID)
 		if s.Action != nil {
-			line := "    action: " + actionLabel(s.Action)
+			line := "    action: " + planshared.ActionLabel(s.Action)
 			if s.Action.Revision > 0 {
 				line += fmt.Sprintf("   (revision %d)", s.Action.Revision)
 			}
 			fmt.Fprintln(out, line)
-			if img := formatImage(s.Action.Image); img != "" {
+			if img := planshared.FormatImage(s.Action.Image); img != "" {
 				fmt.Fprintf(out, "    image: %s\n", img)
 			}
 			if s.Action.Timeout != "" {
@@ -162,7 +161,7 @@ func printPlanSteps(out io.Writer, steps []*models.PlanStep) {
 // aren't shown here; that resolution is per-execution and lives in
 // plan x get.
 func printStepInputs(out io.Writer, s *models.PlanStep) {
-	values := paramsAsMap(stepArgsValues(s))
+	values := planshared.ParamsAsMap(planshared.StepArgsValues(s))
 	var refs map[string]string
 	if s.Args != nil {
 		refs = s.Args.Refs
@@ -176,7 +175,7 @@ func printStepInputs(out io.Writer, s *models.PlanStep) {
 	}
 	var inputs []wired
 	for name, v := range values {
-		inputs = append(inputs, wired{name, formatValue(v), "set in plan"})
+		inputs = append(inputs, wired{name, planshared.FormatValue(v), "set in plan"})
 	}
 	for name, r := range refs {
 		inputs = append(inputs, wired{name, r, "ref"})
@@ -191,7 +190,7 @@ func printStepInputs(out io.Writer, s *models.PlanStep) {
 		}
 	}
 	for _, in := range inputs {
-		printInputLine(out, "      ", maxName, in.name, in.detail, in.via)
+		planshared.PrintInputLine(out, "      ", maxName, in.name, in.detail, in.via)
 	}
 }
 
@@ -219,96 +218,6 @@ func printStepOutputs(out io.Writer, s *models.PlanStep) {
 	}
 }
 
-// printInputLine emits one input row in the form
-//
-//	<indent><name padded>   ← <detail>   (<via>)
-//
-// or, when there's no detail to show:
-//
-//	<indent><name padded>   (<via>)
-func printInputLine(out io.Writer, indent string, nameWidth int, name, detail, via string) {
-	if detail == "" {
-		fmt.Fprintf(out, "%s%-*s   (%s)\n", indent, nameWidth, name, via)
-		return
-	}
-	fmt.Fprintf(out, "%s%-*s   ← %s   (%s)\n", indent, nameWidth, name, detail, via)
-}
-
-// formatValue renders a parameter value for a detail column. Strings
-// pass through as bare text; everything else round-trips through JSON
-// so objects/arrays stay copy-pasteable into a plan spec rather than
-// rendering as Go's map[a:1] / [1 2] forms. Multi-line and very long
-// values are summarised so they don't break the inline arrow form;
-// users who want the full value can use -o yaml.
-func formatValue(v any) string {
-	if v == nil {
-		return ""
-	}
-	var raw string
-	if s, ok := v.(string); ok {
-		raw = s
-	} else {
-		b, err := json.Marshal(v)
-		if err != nil {
-			return fmt.Sprintf("%v", v)
-		}
-		raw = string(b)
-	}
-	return truncateForDisplay(raw)
-}
-
-// maxValueDisplay caps single-line value rendering.
-const maxValueDisplay = 80
-
-// truncateForDisplay collapses a value into a single line suitable
-// for the inline arrow form. Multi-line values are reduced to the
-// first line + a (N lines) marker; over-long single lines get a
-// trailing ellipsis.
-func truncateForDisplay(s string) string {
-	trimmed := strings.TrimRight(s, "\n")
-	if firstLine, _, multiline := strings.Cut(trimmed, "\n"); multiline {
-		nLines := strings.Count(trimmed, "\n") + 1
-		if len(firstLine) > maxValueDisplay {
-			firstLine = firstLine[:maxValueDisplay]
-		}
-		return fmt.Sprintf("%s… (%d lines)", firstLine, nLines)
-	}
-	if len(trimmed) > maxValueDisplay {
-		return trimmed[:maxValueDisplay] + "…"
-	}
-	return trimmed
-}
-
-// actionLabel renders the step's action as "name (id)" when the
-// server returns both, name alone when the ID is empty, or ID alone
-// when the name isn't populated yet (older plans compiled before the
-// Name field was added).
-func actionLabel(a *models.PlanStepAction) string {
-	if a == nil {
-		return ""
-	}
-	if a.Name == "" {
-		return a.ActionID
-	}
-	if a.ActionID == "" {
-		return a.Name
-	}
-	return fmt.Sprintf("%s (%s)", a.Name, a.ActionID)
-}
-
-func formatImage(ref *models.PlanImageRef) string {
-	if ref == nil {
-		return ""
-	}
-	if ref.Literal != "" {
-		return ref.Literal
-	}
-	if ref.InputName != "" {
-		return fmt.Sprintf("(from input %q)", ref.InputName)
-	}
-	return ""
-}
-
 func formatFieldSchema(f *models.PlanField) string {
 	if f.SchemaRef != "" {
 		return fmt.Sprintf("schema: %s", f.SchemaRef)
@@ -319,18 +228,4 @@ func formatFieldSchema(f *models.PlanField) string {
 		}
 	}
 	return ""
-}
-
-func stepArgsValues(s *models.PlanStep) any {
-	if s == nil || s.Args == nil {
-		return nil
-	}
-	return s.Args.Values
-}
-
-func paramsAsMap(v any) map[string]any {
-	if m, ok := v.(map[string]any); ok {
-		return m
-	}
-	return nil
 }

--- a/internal/command/plan/run.go
+++ b/internal/command/plan/run.go
@@ -102,7 +102,11 @@ func runPlan(cfg *config.PlanRun, out, log io.Writer, args []string) error {
 		return fmt.Errorf("creating execution: %w", err)
 	}
 	execID := createResp.Payload.ID
-	if cfg.OutputFormat == config.OutputFormatDefault {
+	// In --attach mode the "created" notice is emitted as a structured
+	// event from inside attachExecution so it shares timestamping and
+	// formatting with the rest of the stream. Otherwise print a plain
+	// banner to stderr (only for default text output).
+	if cfg.OutputFormat == config.OutputFormatDefault && !cfg.Attach {
 		fmt.Fprintf(log, "Created execution %s for plan %s\n", execID, planID)
 	}
 
@@ -114,7 +118,7 @@ func runPlan(cfg *config.PlanRun, out, log io.Writer, args []string) error {
 	// Wait for completion: attach streams structured events, otherwise poll with spinner.
 	var exec *models.PlanExecution
 	if cfg.Attach {
-		exec, err = attachExecution(ctx, cfg, out, log, execID)
+		exec, err = attachExecution(ctx, cfg, out, log, execID, planID)
 	} else {
 		exec, err = pollExecution(ctx, cfg, log, execID)
 	}
@@ -300,6 +304,35 @@ func applyRoutingFlags(cfg *config.PlanRun, planSpec *models.PlanSpec, params ma
 	return nil
 }
 
+// buildOutputEvent translates a plan-level PlanOutputStatus into the
+// AttachEvent shape so an --attach text/JSON consumer can tell inline
+// outputs (Kind=inline, Value set) from artifact outputs (Kind=artifact,
+// Size/Ready/ContentType set) instead of seeing value=<nil> for the
+// latter.
+func buildOutputEvent(o *models.PlanOutputStatus) sdkprint.AttachEvent {
+	evt := sdkprint.AttachEvent{
+		Type: "output",
+		Name: o.Name,
+	}
+	if o.StepRef != nil {
+		evt.Step = o.StepRef.StepID
+	}
+	if o.Artifact != nil {
+		evt.Kind = "artifact"
+		evt.Size = o.Artifact.Size
+		ready := o.Artifact.Ready
+		evt.Ready = &ready
+		if ct := o.Metadata["contentType"]; ct != "" {
+			evt.ContentType = ct
+		}
+		evt.Error = o.Artifact.Error
+	} else {
+		evt.Kind = "inline"
+		evt.Value = o.Value
+	}
+	return evt
+}
+
 func isTerminal(phase models.PlansExecutionPhase) bool {
 	switch phase {
 	case models.PlansExecutionPhaseCompleted,
@@ -367,7 +400,7 @@ func pollExecution(ctx context.Context, cfg *config.PlanRun, log io.Writer, exec
 	}
 }
 
-func attachExecution(ctx context.Context, cfg *config.PlanRun, out, log io.Writer, execID string) (*models.PlanExecution, error) {
+func attachExecution(ctx context.Context, cfg *config.PlanRun, out, log io.Writer, execID, planID string) (*models.PlanExecution, error) {
 	if cfg.Timeout > 0 {
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithTimeout(ctx, cfg.Timeout)
@@ -376,6 +409,15 @@ func attachExecution(ctx context.Context, cfg *config.PlanRun, out, log io.Write
 
 	jsonMode := cfg.OutputFormat == config.OutputFormatJSON
 	aw := sdkprint.NewAttachWriter(out, jsonMode)
+
+	// First event in the stream — same shape as the "Created execution"
+	// stderr banner emitted in non-attach mode, so consumers piping
+	// through jq see a consistent event sequence from creation to result.
+	aw.Emit(sdkprint.AttachEvent{
+		Type:   "created",
+		ID:     execID,
+		PlanID: planID,
+	})
 
 	// Stream aggregated logs in background, emitting structured events.
 	logCtx, logCancel := context.WithCancel(ctx)
@@ -444,11 +486,7 @@ func attachExecution(ctx context.Context, cfg *config.PlanRun, out, log io.Write
 			// Emit output events for resolved plan-level outputs.
 			if ex.Status != nil {
 				for _, o := range ex.Status.Outputs {
-					aw.Emit(sdkprint.AttachEvent{
-						Type:  "output",
-						Name:  o.Name,
-						Value: o.Value,
-					})
+					aw.Emit(buildOutputEvent(o))
 				}
 			}
 			// Emit result event.

--- a/internal/command/plan/run.go
+++ b/internal/command/plan/run.go
@@ -108,7 +108,7 @@ func runPlan(cfg *config.PlanRun, out, log io.Writer, args []string) error {
 
 	// Fire-and-forget mode.
 	if !cfg.Wait {
-		return writeRunOutput(cfg, out, createResp.Payload)
+		return writeRunOutput(cfg, out, createResp.Payload, planSpec)
 	}
 
 	// Wait for completion: attach streams structured events, otherwise poll with spinner.
@@ -156,17 +156,17 @@ func runPlan(cfg *config.PlanRun, out, log io.Writer, args []string) error {
 	// On failure/cancellation, write details to stderr so stdout stays clean.
 	switch exec.Status.Phase {
 	case models.PlansExecutionPhaseFailed:
-		if err := writeRunOutput(cfg, log, exec); err != nil {
+		if err := writeRunOutput(cfg, log, exec, planSpec); err != nil {
 			fmt.Fprintf(log, "error rendering output: %v\n", err)
 		}
 		os.Exit(1)
 	case models.PlansExecutionPhaseCancelled:
-		if err := writeRunOutput(cfg, log, exec); err != nil {
+		if err := writeRunOutput(cfg, log, exec, planSpec); err != nil {
 			fmt.Fprintf(log, "error rendering output: %v\n", err)
 		}
 		os.Exit(2)
 	default:
-		return writeRunOutput(cfg, out, exec)
+		return writeRunOutput(cfg, out, exec, planSpec)
 	}
 	return nil
 }
@@ -475,14 +475,14 @@ func attachExecution(ctx context.Context, cfg *config.PlanRun, out, log io.Write
 	}
 }
 
-func writeRunOutput(cfg *config.PlanRun, out io.Writer, exec *models.PlanExecution) error {
+func writeRunOutput(cfg *config.PlanRun, out io.Writer, exec *models.PlanExecution, planSpec *models.PlanSpec) error {
 	switch cfg.OutputFormat {
 	case config.OutputFormatJSON:
 		return sdkprint.RawJSON(out, exec)
 	case config.OutputFormatYAML:
 		return sdkprint.RawYAML(out, exec)
 	default:
-		return planexec.PrintRunResult(out, exec)
+		return planexec.PrintRunResult(out, exec, planSpec)
 	}
 }
 

--- a/internal/command/planaction/printers.go
+++ b/internal/command/planaction/printers.go
@@ -9,6 +9,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/charmbracelet/glamour"
+	"github.com/signadot/cli/internal/command/planshared"
 	"github.com/signadot/cli/internal/sdtab"
 	"github.com/signadot/cli/internal/utils"
 	"github.com/signadot/go-sdk/models"
@@ -71,7 +72,7 @@ func printActionDetails(out io.Writer, a *models.PlanAction) error {
 		if a.Status.UpdatedAt != "" {
 			fmt.Fprintf(tw, "Updated:\t%s\n", utils.FormatTimestamp(a.Status.UpdatedAt))
 		}
-		if img := formatImage(a.Status.BodyImage); img != "" {
+		if img := planshared.FormatImage(a.Status.BodyImage); img != "" {
 			fmt.Fprintf(tw, "Image:\t%s\n", img)
 		}
 	}
@@ -138,19 +139,6 @@ func enabled(a *models.PlanAction) string {
 		return ""
 	}
 	return fmt.Sprintf("%t", a.Status.Enabled)
-}
-
-func formatImage(ref *models.PlanImageRef) string {
-	if ref == nil {
-		return ""
-	}
-	if ref.Literal != "" {
-		return ref.Literal
-	}
-	if ref.InputName != "" {
-		return fmt.Sprintf("(from input %q)", ref.InputName)
-	}
-	return ""
 }
 
 type fieldRow struct {

--- a/internal/command/planaction/printers.go
+++ b/internal/command/planaction/printers.go
@@ -71,9 +71,6 @@ func printActionDetails(out io.Writer, a *models.PlanAction) error {
 		if a.Status.UpdatedAt != "" {
 			fmt.Fprintf(tw, "Updated:\t%s\n", utils.FormatTimestamp(a.Status.UpdatedAt))
 		}
-		if len(a.Status.Requires) > 0 {
-			fmt.Fprintf(tw, "Requires:\t%s\n", strings.Join(a.Status.Requires, ", "))
-		}
 		if img := formatImage(a.Status.BodyImage); img != "" {
 			fmt.Fprintf(tw, "Image:\t%s\n", img)
 		}
@@ -87,9 +84,6 @@ func printActionDetails(out io.Writer, a *models.PlanAction) error {
 			return err
 		}
 		if err := printFields(out, "Outputs", a.Status.BodyOutputs); err != nil {
-			return err
-		}
-		if err := printValidations(out, a.Status.Validations); err != nil {
 			return err
 		}
 	}
@@ -180,32 +174,6 @@ func printFields(out io.Writer, label string, fields []*models.PlanField) error 
 			Required: fmt.Sprintf("%t", f.Required),
 			Default:  formatAny(f.Default),
 			Schema:   formatSchema(f),
-		})
-	}
-	return t.Flush()
-}
-
-type validationRow struct {
-	RunnerGroup string `sdtab:"RUNNER GROUP"`
-	Valid       string `sdtab:"VALID"`
-	Stale       string `sdtab:"STALE"`
-	Validated   string `sdtab:"VALIDATED"`
-}
-
-func printValidations(out io.Writer, vs []*models.PlanActionValidationStatus) error {
-	if len(vs) == 0 {
-		return nil
-	}
-	fmt.Fprintln(out)
-	fmt.Fprintln(out, "Validations:")
-	t := sdtab.New[validationRow](out)
-	t.AddHeader()
-	for _, v := range vs {
-		t.AddRow(validationRow{
-			RunnerGroup: v.RunnerGroup,
-			Valid:       fmt.Sprintf("%t", v.Valid),
-			Stale:       fmt.Sprintf("%t", v.Stale),
-			Validated:   utils.FormatTimestamp(v.ValidatedAt),
 		})
 	}
 	return t.Flush()

--- a/internal/command/planexec/cancel.go
+++ b/internal/command/planexec/cancel.go
@@ -40,7 +40,7 @@ func cancelExec(cfg *config.PlanExecCancel, out, log io.Writer, execID string) e
 
 	switch cfg.OutputFormat {
 	case config.OutputFormatDefault:
-		return printExecDetails(out, resp.Payload)
+		return printExecDetails(out, resp.Payload, fetchPlanSpec(cfg.API, resp.Payload))
 	case config.OutputFormatJSON:
 		return print.RawJSON(out, resp.Payload)
 	case config.OutputFormatYAML:

--- a/internal/command/planexec/get.go
+++ b/internal/command/planexec/get.go
@@ -7,6 +7,8 @@ import (
 	"github.com/signadot/cli/internal/config"
 	"github.com/signadot/cli/internal/print"
 	planexecs "github.com/signadot/go-sdk/client/plan_executions"
+	sdkplans "github.com/signadot/go-sdk/client/plans"
+	"github.com/signadot/go-sdk/models"
 	"github.com/spf13/cobra"
 )
 
@@ -39,7 +41,7 @@ func getExec(cfg *config.PlanExecGet, out io.Writer, execID string) error {
 
 	switch cfg.OutputFormat {
 	case config.OutputFormatDefault:
-		return printExecDetails(out, resp.Payload)
+		return printExecDetails(out, resp.Payload, fetchPlanSpec(cfg.API, resp.Payload))
 	case config.OutputFormatJSON:
 		return print.RawJSON(out, resp.Payload)
 	case config.OutputFormatYAML:
@@ -47,4 +49,21 @@ func getExec(cfg *config.PlanExecGet, out io.Writer, execID string) error {
 	default:
 		return fmt.Errorf("unsupported output format: %q", cfg.OutputFormat)
 	}
+}
+
+// fetchPlanSpec returns the spec of the plan referenced by ex, or nil
+// if the plan can't be fetched (deleted, network error, etc). The
+// detail printer renders without resolved values when the spec is nil.
+func fetchPlanSpec(api *config.API, ex *models.PlanExecution) *models.PlanSpec {
+	if ex == nil || ex.Spec == nil || ex.Spec.PlanID == "" {
+		return nil
+	}
+	params := sdkplans.NewGetPlanParams().
+		WithOrgName(api.Org).
+		WithPlanID(ex.Spec.PlanID)
+	resp, err := api.Client.Plans.GetPlan(params, nil)
+	if err != nil || resp.Payload == nil {
+		return nil
+	}
+	return resp.Payload.Spec
 }

--- a/internal/command/planexec/printers.go
+++ b/internal/command/planexec/printers.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"strings"
 	"text/tabwriter"
 
 	"github.com/docker/go-units"
@@ -12,40 +13,12 @@ import (
 	"github.com/signadot/go-sdk/models"
 )
 
-// PrintRunResult prints execution details with output summary for plan run.
-// Inline values are printed to stdout; artifact outputs are listed by reference.
-// planSpec is the compiled plan being executed; when non-nil it is used to
-// resolve literal/default input values into the per-step detail. Pass nil
-// when the plan spec isn't available (e.g. the plan was deleted).
+// PrintRunResult is a thin wrapper around printExecDetails for the
+// plan run path. The output-rendering logic that used to live here
+// now lives in printExecDetails so plan x get and plan x cancel see
+// the same trailing inline values + artifact outputs section.
 func PrintRunResult(out io.Writer, ex *models.PlanExecution, planSpec *models.PlanSpec) error {
-	if err := printExecDetails(out, ex, planSpec); err != nil {
-		return err
-	}
-
-	if ex.Status == nil || len(ex.Status.Outputs) == 0 {
-		return nil
-	}
-
-	// Print inline values directly.
-	for _, o := range ex.Status.Outputs {
-		if o.Value != nil {
-			fmt.Fprintf(out, "\n--- %s ---\n%v\n", o.Name, o.Value)
-		}
-	}
-
-	// List artifact outputs by reference.
-	var artifacts []*models.PlanOutputStatus
-	for _, o := range ex.Status.Outputs {
-		if o.Artifact != nil {
-			artifacts = append(artifacts, o)
-		}
-	}
-	if len(artifacts) > 0 {
-		fmt.Fprintln(out)
-		fmt.Fprintln(out, "Artifact outputs:")
-		return printOutputsTable(out, artifacts)
-	}
-	return nil
+	return printExecDetails(out, ex, planSpec)
 }
 
 func printExecDetails(out io.Writer, ex *models.PlanExecution, planSpec *models.PlanSpec) error {
@@ -102,7 +75,86 @@ func printExecDetails(out io.Writer, ex *models.PlanExecution, planSpec *models.
 		printSteps(out, ex.Status.Steps, planSpec)
 	}
 
+	printExecOutputs(out, ex)
 	return nil
+}
+
+// printExecOutputs renders an execution's plan-level outputs in the
+// indented arrow form used by the rest of the detail view. Inline
+// values get the arrow + truncated value; artifacts show kind/size.
+// Each row is annotated with the source step (StepRef) when set.
+// Skipped for executions with no plan-level outputs.
+func printExecOutputs(out io.Writer, ex *models.PlanExecution) {
+	if ex.Status == nil || len(ex.Status.Outputs) == 0 {
+		return
+	}
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "Outputs:")
+	maxName := 0
+	for _, o := range ex.Status.Outputs {
+		if o != nil && len(o.Name) > maxName {
+			maxName = len(o.Name)
+		}
+	}
+	for _, o := range ex.Status.Outputs {
+		if o == nil {
+			continue
+		}
+		stepID := ""
+		if o.StepRef != nil {
+			stepID = o.StepRef.StepID
+		}
+		printOutputRow(out, "  ", maxName, o.Name, o.Value, o.Artifact, o.Metadata, stepID)
+	}
+}
+
+// printOutputRow emits one output entry. Inline values use the arrow
+// form; artifacts have no inline value, just the kind/size tag.
+// stepID, when non-empty, is appended to the tag as ", from <stepID>"
+// — used for plan-level outputs to surface which step produced them.
+func printOutputRow(out io.Writer, indent string, nameWidth int, name string, value any, art *models.PlanArtifactRef, metadata map[string]string, stepID string) {
+	detail := ""
+	if value != nil {
+		detail = formatValue(value)
+	}
+	printInputLine(out, indent, nameWidth, name, detail, formatOutputTag(art, metadata, stepID))
+}
+
+// formatOutputTag renders the parenthesized tag content for an
+// output:
+//
+//	inline                      — for inline values
+//	artifact, <size>, ready     — for artifacts (ready state always shown)
+//	artifact, <size>, not ready
+//
+// When the output's metadata carries a "contentType" key it's
+// appended after the ready flag. A non-empty stepID adds a trailing
+// ", from <stepID>" for plan-level rollups.
+func formatOutputTag(art *models.PlanArtifactRef, metadata map[string]string, stepID string) string {
+	var parts []string
+	if art != nil {
+		parts = append(parts, "artifact")
+		if art.Size > 0 {
+			parts = append(parts, units.HumanSize(float64(art.Size)))
+		}
+		if art.Ready {
+			parts = append(parts, "ready")
+		} else {
+			parts = append(parts, "not ready")
+		}
+		if ct := metadata["contentType"]; ct != "" {
+			parts = append(parts, ct)
+		}
+		if art.Error != "" {
+			parts = append(parts, "error: "+art.Error)
+		}
+	} else {
+		parts = append(parts, "inline")
+	}
+	if stepID != "" {
+		parts = append(parts, "from "+stepID)
+	}
+	return strings.Join(parts, ", ")
 }
 
 // printPlanInputs prints plan-level params in the indented arrow form
@@ -199,38 +251,52 @@ func printSteps(out io.Writer, steps []*models.PlanStepStatus, planSpec *models.
 		if s.Error != "" {
 			fmt.Fprintf(out, "    error: %s\n", s.Error)
 		}
-		if len(s.Inputs) == 0 {
-			continue
-		}
-		fmt.Fprintln(out, "    inputs:")
-		stepValues := paramsAsMap(stepArgsValues(step))
-		maxName := 0
-		for _, in := range s.Inputs {
-			if len(in.Name) > maxName {
-				maxName = len(in.Name)
-			}
-		}
-		for _, in := range s.Inputs {
-			detail := ""
-			switch in.ResolvedVia {
-			case models.PlansInputResolvedViaRef:
-				detail = in.Ref
-			case models.PlansInputResolvedViaLiteral:
-				if v, ok := stepValues[in.Name]; ok {
-					detail = formatValue(v)
-				}
-			case models.PlansInputResolvedViaDefault:
-				if p := findStepInputDecl(step, in.Name); p != nil && p.Default != nil {
-					detail = formatValue(p.Default)
+		if len(s.Inputs) > 0 {
+			fmt.Fprintln(out, "    inputs:")
+			stepValues := paramsAsMap(stepArgsValues(step))
+			maxName := 0
+			for _, in := range s.Inputs {
+				if len(in.Name) > maxName {
+					maxName = len(in.Name)
 				}
 			}
-			printInputLine(out, "      ", maxName, in.Name, detail, stepLevelVia(in.ResolvedVia))
+			for _, in := range s.Inputs {
+				detail := ""
+				switch in.ResolvedVia {
+				case models.PlansInputResolvedViaRef:
+					detail = in.Ref
+				case models.PlansInputResolvedViaLiteral:
+					if v, ok := stepValues[in.Name]; ok {
+						detail = formatValue(v)
+					}
+				case models.PlansInputResolvedViaDefault:
+					if p := findStepInputDecl(step, in.Name); p != nil && p.Default != nil {
+						detail = formatValue(p.Default)
+					}
+				}
+				printInputLine(out, "      ", maxName, in.Name, detail, stepLevelVia(in.ResolvedVia))
+			}
+		}
+		if len(s.Outputs) > 0 {
+			fmt.Fprintln(out, "    outputs:")
+			maxName := 0
+			for _, o := range s.Outputs {
+				if o != nil && len(o.Name) > maxName {
+					maxName = len(o.Name)
+				}
+			}
+			for _, o := range s.Outputs {
+				if o == nil {
+					continue
+				}
+				printOutputRow(out, "      ", maxName, o.Name, o.Value, o.Artifact, o.Metadata, "")
+			}
 		}
 	}
 }
 
 func hasStepBody(s *models.PlanStepStatus) bool {
-	return len(s.Inputs) > 0 || s.Error != ""
+	return len(s.Inputs) > 0 || len(s.Outputs) > 0 || s.Error != ""
 }
 
 // actionLabel renders the step's action as "name (id)" when the
@@ -274,19 +340,48 @@ func printInputLine(out io.Writer, indent string, nameWidth int, name, detail, v
 // formatValue renders a parameter value for a detail column. Strings
 // pass through as bare text; everything else round-trips through JSON
 // so objects/arrays stay copy-pasteable into a plan spec rather than
-// rendering as Go's map[a:1] / [1 2] forms.
+// rendering as Go's map[a:1] / [1 2] forms. Multi-line and very long
+// values are summarised so they don't break the inline arrow form;
+// users who want the full value can use -o yaml.
 func formatValue(v any) string {
 	if v == nil {
 		return ""
 	}
+	var raw string
 	if s, ok := v.(string); ok {
-		return s
+		raw = s
+	} else {
+		b, err := json.Marshal(v)
+		if err != nil {
+			return fmt.Sprintf("%v", v)
+		}
+		raw = string(b)
 	}
-	b, err := json.Marshal(v)
-	if err != nil {
-		return fmt.Sprintf("%v", v)
+	return truncateForDisplay(raw)
+}
+
+// maxValueDisplay caps single-line value rendering. Keeps room on a
+// 100-column terminal for the indent + name + arrow + via tag
+// surrounding the value.
+const maxValueDisplay = 80
+
+// truncateForDisplay collapses a value into a single line suitable
+// for the inline arrow form. Multi-line values are reduced to the
+// first line + a (N lines) marker; over-long single lines get a
+// trailing ellipsis.
+func truncateForDisplay(s string) string {
+	trimmed := strings.TrimRight(s, "\n")
+	if firstLine, _, multiline := strings.Cut(trimmed, "\n"); multiline {
+		nLines := strings.Count(trimmed, "\n") + 1
+		if len(firstLine) > maxValueDisplay {
+			firstLine = firstLine[:maxValueDisplay]
+		}
+		return fmt.Sprintf("%s… (%d lines)", firstLine, nLines)
 	}
-	return string(b)
+	if len(trimmed) > maxValueDisplay {
+		return trimmed[:maxValueDisplay] + "…"
+	}
+	return trimmed
 }
 
 func execParams(ex *models.PlanExecution) any {
@@ -355,45 +450,6 @@ func findStepInputDecl(step *models.PlanStep, name string) *models.PlanField {
 		}
 	}
 	return nil
-}
-
-type outputRow struct {
-	Name  string `sdtab:"NAME"`
-	Step  string `sdtab:"STEP"`
-	Type  string `sdtab:"TYPE"`
-	Size  string `sdtab:"SIZE"`
-	Ready string `sdtab:"READY"`
-}
-
-func printOutputsTable(out io.Writer, outputs []*models.PlanOutputStatus) error {
-	t := sdtab.New[outputRow](out)
-	t.AddHeader()
-	for _, o := range outputs {
-		step := ""
-		if o.StepRef != nil {
-			step = o.StepRef.StepID
-		}
-		typ := "inline"
-		size := ""
-		ready := "-"
-		if o.Artifact != nil {
-			typ = "artifact"
-			size = units.HumanSize(float64(o.Artifact.Size))
-			if o.Artifact.Ready {
-				ready = "true"
-			} else {
-				ready = "false"
-			}
-		}
-		t.AddRow(outputRow{
-			Name:  o.Name,
-			Step:  step,
-			Type:  typ,
-			Size:  size,
-			Ready: ready,
-		})
-	}
-	return t.Flush()
 }
 
 type allOutputRow struct {

--- a/internal/command/planexec/printers.go
+++ b/internal/command/planexec/printers.go
@@ -1,6 +1,7 @@
 package planexec
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"text/tabwriter"
@@ -13,8 +14,11 @@ import (
 
 // PrintRunResult prints execution details with output summary for plan run.
 // Inline values are printed to stdout; artifact outputs are listed by reference.
-func PrintRunResult(out io.Writer, ex *models.PlanExecution) error {
-	if err := printExecDetails(out, ex); err != nil {
+// planSpec is the compiled plan being executed; when non-nil it is used to
+// resolve literal/default input values into the per-step detail. Pass nil
+// when the plan spec isn't available (e.g. the plan was deleted).
+func PrintRunResult(out io.Writer, ex *models.PlanExecution, planSpec *models.PlanSpec) error {
+	if err := printExecDetails(out, ex, planSpec); err != nil {
 		return err
 	}
 
@@ -44,7 +48,7 @@ func PrintRunResult(out io.Writer, ex *models.PlanExecution) error {
 	return nil
 }
 
-func printExecDetails(out io.Writer, ex *models.PlanExecution) error {
+func printExecDetails(out io.Writer, ex *models.PlanExecution, planSpec *models.PlanSpec) error {
 	tw := tabwriter.NewWriter(out, 0, 0, 3, ' ', 0)
 
 	fmt.Fprintf(tw, "ID:\t%s\n", ex.ID)
@@ -89,82 +93,245 @@ func printExecDetails(out io.Writer, ex *models.PlanExecution) error {
 	if ex.Status != nil && len(ex.Status.Inputs) > 0 {
 		fmt.Fprintln(out)
 		fmt.Fprintln(out, "Inputs:")
-		printPlanInputs(out, ex.Status.Inputs)
+		printPlanInputs(out, ex, planSpec)
 	}
 
 	if ex.Status != nil && len(ex.Status.Steps) > 0 {
 		fmt.Fprintln(out)
 		fmt.Fprintln(out, "Steps:")
-		printSteps(out, ex.Status.Steps)
+		printSteps(out, ex.Status.Steps, planSpec)
 	}
 
 	return nil
 }
 
-// isInterestingInput reports whether an input's resolution mechanism is
-// worth showing in the per-step detail. Pure literal/default/unbound
-// resolutions are noise; refs and secret-backed inputs are the
-// actionable cases. Unknown enum values are treated as interesting so
-// a server-side schema addition surfaces rather than getting silently
-// filtered.
-func isInterestingInput(via models.PlansInputResolvedVia) bool {
-	switch via {
-	case models.PlansInputResolvedViaLiteral,
-		models.PlansInputResolvedViaDefault,
-		models.PlansInputResolvedViaUnbound:
-		return false
-	}
-	return true
-}
-
 // printPlanInputs prints plan-level params in the indented arrow form
-// used throughout the steps section. All plan-level inputs are shown
-// (including literal/default/unbound) since this is the authoritative
-// view of what bound at dispatch time.
-func printPlanInputs(out io.Writer, inputs []*models.PlanInputStatus) {
-	tw := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
+// used throughout the steps section. All entries are shown so the
+// reader sees the authoritative view of what bound at dispatch time.
+// Literal values are taken from execution.spec.params; default values
+// are pulled from the plan spec when it's available.
+func printPlanInputs(out io.Writer, ex *models.PlanExecution, planSpec *models.PlanSpec) {
+	inputs := ex.Status.Inputs
+	maxName := 0
+	for _, i := range inputs {
+		if len(i.Name) > maxName {
+			maxName = len(i.Name)
+		}
+	}
+	suppliedParams := paramsAsMap(execParams(ex))
 	for _, i := range inputs {
 		detail := ""
-		if i.SecretName != "" {
+		switch i.ResolvedVia {
+		case models.PlansInputResolvedViaCallerSecret:
 			detail = i.SecretName
+		case models.PlansInputResolvedViaLiteral:
+			if v, ok := suppliedParams[i.Name]; ok {
+				detail = formatValue(v)
+			}
+		case models.PlansInputResolvedViaDefault:
+			if p := findPlanParam(planSpec, i.Name); p != nil && p.Default != nil {
+				detail = formatValue(p.Default)
+			}
 		}
-		printInputLine(tw, "  ", i.Name, detail, string(i.ResolvedVia))
+		printInputLine(out, "  ", maxName, i.Name, detail, planLevelVia(i.ResolvedVia))
 	}
-	tw.Flush()
 }
 
-func printSteps(out io.Writer, steps []*models.PlanStepStatus) {
-	tw := tabwriter.NewWriter(out, 0, 0, 3, ' ', 0)
+// planLevelVia renders a plan-level input's resolution method as
+// human-readable prose. The plain enum names (literal, default, ...)
+// are ambiguous at this level: "literal" really means "the caller
+// passed --param" and "default" means "the plan's declared default
+// kicked in".
+func planLevelVia(via models.PlansInputResolvedVia) string {
+	switch via {
+	case models.PlansInputResolvedViaLiteral:
+		return "from --param"
+	case models.PlansInputResolvedViaCallerSecret:
+		return "from --param-secret"
+	case models.PlansInputResolvedViaDefault:
+		return "plan default"
+	case models.PlansInputResolvedViaUnbound:
+		return "unbound"
+	}
+	return string(via)
+}
+
+// stepLevelVia renders a step-level input's resolution method as
+// human-readable prose. "literal" at this level means the plan author
+// wrote the value directly into step args (rather than the caller
+// supplying it), so we say "set in plan".
+func stepLevelVia(via models.PlansInputResolvedVia) string {
+	switch via {
+	case models.PlansInputResolvedViaLiteral:
+		return "set in plan"
+	case models.PlansInputResolvedViaRef:
+		return "ref"
+	case models.PlansInputResolvedViaDefault:
+		return "default"
+	case models.PlansInputResolvedViaUnbound:
+		return "unbound"
+	}
+	return string(via)
+}
+
+func printSteps(out io.Writer, steps []*models.PlanStepStatus, planSpec *models.PlanSpec) {
+	maxID := 0
 	for _, s := range steps {
-		fmt.Fprintf(tw, "  %s\t%s\n", s.ID, s.Phase)
-		if s.Error != "" {
-			fmt.Fprintf(tw, "      error:\t%s\n", s.Error)
-		}
-		for _, i := range s.Inputs {
-			if !isInterestingInput(i.ResolvedVia) {
-				continue
-			}
-			printInputLine(tw, "      ", i.Name, i.Ref, string(i.ResolvedVia))
+		if len(s.ID) > maxID {
+			maxID = len(s.ID)
 		}
 	}
-	tw.Flush()
+	for i, s := range steps {
+		if i > 0 && hasStepBody(s) {
+			fmt.Fprintln(out)
+		}
+		fmt.Fprintf(out, "  %-*s   %s\n", maxID, s.ID, s.Phase)
+		if !hasStepBody(s) {
+			continue
+		}
+		if s.Error != "" {
+			fmt.Fprintf(out, "    error: %s\n", s.Error)
+		}
+		if len(s.Inputs) == 0 {
+			continue
+		}
+		fmt.Fprintln(out, "    inputs:")
+		step := findStep(planSpec, s.ID)
+		stepValues := paramsAsMap(stepArgsValues(step))
+		maxName := 0
+		for _, in := range s.Inputs {
+			if len(in.Name) > maxName {
+				maxName = len(in.Name)
+			}
+		}
+		for _, in := range s.Inputs {
+			detail := ""
+			switch in.ResolvedVia {
+			case models.PlansInputResolvedViaRef:
+				detail = in.Ref
+			case models.PlansInputResolvedViaLiteral:
+				if v, ok := stepValues[in.Name]; ok {
+					detail = formatValue(v)
+				}
+			case models.PlansInputResolvedViaDefault:
+				if p := findStepInputDecl(step, in.Name); p != nil && p.Default != nil {
+					detail = formatValue(p.Default)
+				}
+			}
+			printInputLine(out, "      ", maxName, in.Name, detail, stepLevelVia(in.ResolvedVia))
+		}
+	}
+}
+
+func hasStepBody(s *models.PlanStepStatus) bool {
+	return len(s.Inputs) > 0 || s.Error != ""
 }
 
 // printInputLine emits one input row in the form
 //
-//	<indent><name>  ←  <detail>  (<via>)
+//	<indent><name padded>   ← <detail>   (<via>)
 //
 // or, when there's no detail to show:
 //
-//	<indent><name>  (<via>)
+//	<indent><name padded>   (<via>)
 //
-// Tab stops keep the arrows aligned within a single tabwriter scope.
-func printInputLine(tw io.Writer, indent, name, detail, via string) {
+// Manual padding is used (rather than tabwriter) because rows with
+// and without a detail cell have different "shapes"; a single
+// tabwriter scope would size the empty middle column based on the
+// longest detail and leave the (via) tag for no-detail rows pushed
+// far to the right.
+func printInputLine(out io.Writer, indent string, nameWidth int, name, detail, via string) {
 	if detail == "" {
-		fmt.Fprintf(tw, "%s%s\t\t(%s)\n", indent, name, via)
+		fmt.Fprintf(out, "%s%-*s   (%s)\n", indent, nameWidth, name, via)
 		return
 	}
-	fmt.Fprintf(tw, "%s%s\t← %s\t(%s)\n", indent, name, detail, via)
+	fmt.Fprintf(out, "%s%-*s   ← %s   (%s)\n", indent, nameWidth, name, detail, via)
+}
+
+// formatValue renders a parameter value for a detail column. Strings
+// pass through as bare text; everything else round-trips through JSON
+// so objects/arrays stay copy-pasteable into a plan spec rather than
+// rendering as Go's map[a:1] / [1 2] forms.
+func formatValue(v any) string {
+	if v == nil {
+		return ""
+	}
+	if s, ok := v.(string); ok {
+		return s
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return fmt.Sprintf("%v", v)
+	}
+	return string(b)
+}
+
+func execParams(ex *models.PlanExecution) any {
+	if ex == nil || ex.Spec == nil {
+		return nil
+	}
+	return ex.Spec.Params
+}
+
+func stepArgsValues(step *models.PlanStep) any {
+	if step == nil || step.Args == nil {
+		return nil
+	}
+	return step.Args.Values
+}
+
+func paramsAsMap(v any) map[string]any {
+	if m, ok := v.(map[string]any); ok {
+		return m
+	}
+	return nil
+}
+
+func findPlanParam(planSpec *models.PlanSpec, name string) *models.PlanField {
+	if planSpec == nil {
+		return nil
+	}
+	for _, p := range planSpec.Params {
+		if p != nil && p.Name == name {
+			return p
+		}
+	}
+	return nil
+}
+
+func findStep(planSpec *models.PlanSpec, stepID string) *models.PlanStep {
+	if planSpec == nil {
+		return nil
+	}
+	for _, s := range planSpec.Steps {
+		if s != nil && s.ID == stepID {
+			return s
+		}
+	}
+	return nil
+}
+
+// findStepInputDecl looks up a step input by name, searching the
+// action's declared params first and falling back to the step's
+// declared extra_inputs. Either can carry a Default the runner
+// resolved against.
+func findStepInputDecl(step *models.PlanStep, name string) *models.PlanField {
+	if step == nil {
+		return nil
+	}
+	if step.Action != nil {
+		for _, p := range step.Action.Params {
+			if p != nil && p.Name == name {
+				return p
+			}
+		}
+	}
+	for _, p := range step.ExtraInputs {
+		if p != nil && p.Name == name {
+			return p
+		}
+	}
+	return nil
 }
 
 type outputRow struct {

--- a/internal/command/planexec/printers.go
+++ b/internal/command/planexec/printers.go
@@ -1,13 +1,13 @@
 package planexec
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 	"strings"
 	"text/tabwriter"
 
 	"github.com/docker/go-units"
+	"github.com/signadot/cli/internal/command/planshared"
 	"github.com/signadot/cli/internal/sdtab"
 	"github.com/signadot/cli/internal/utils"
 	"github.com/signadot/go-sdk/models"
@@ -66,7 +66,11 @@ func printExecDetails(out io.Writer, ex *models.PlanExecution, planSpec *models.
 	if ex.Status != nil && len(ex.Status.Inputs) > 0 {
 		fmt.Fprintln(out)
 		fmt.Fprintln(out, "Inputs:")
-		printPlanInputs(out, ex, planSpec)
+		var supplied any
+		if ex.Spec != nil {
+			supplied = ex.Spec.Params
+		}
+		printPlanInputs(out, ex.Status.Inputs, supplied, planSpec)
 	}
 
 	if ex.Status != nil && len(ex.Status.Steps) > 0 {
@@ -115,9 +119,9 @@ func printExecOutputs(out io.Writer, ex *models.PlanExecution) {
 func printOutputRow(out io.Writer, indent string, nameWidth int, name string, value any, art *models.PlanArtifactRef, metadata map[string]string, stepID string) {
 	detail := ""
 	if value != nil {
-		detail = formatValue(value)
+		detail = planshared.FormatValue(value)
 	}
-	printInputLine(out, indent, nameWidth, name, detail, formatOutputTag(art, metadata, stepID))
+	planshared.PrintInputLine(out, indent, nameWidth, name, detail, formatOutputTag(art, metadata, stepID))
 }
 
 // formatOutputTag renders the parenthesized tag content for an
@@ -160,32 +164,32 @@ func formatOutputTag(art *models.PlanArtifactRef, metadata map[string]string, st
 // printPlanInputs prints plan-level params in the indented arrow form
 // used throughout the steps section. All entries are shown so the
 // reader sees the authoritative view of what bound at dispatch time.
-// Literal values are taken from execution.spec.params; default values
-// are pulled from the plan spec when it's available.
-func printPlanInputs(out io.Writer, ex *models.PlanExecution, planSpec *models.PlanSpec) {
-	inputs := ex.Status.Inputs
+// suppliedParams is execution.spec.params (the raw any from the
+// SDK); default values are pulled from the plan spec when it's
+// available.
+func printPlanInputs(out io.Writer, inputs []*models.PlanInputStatus, suppliedParams any, planSpec *models.PlanSpec) {
 	maxName := 0
 	for _, i := range inputs {
 		if len(i.Name) > maxName {
 			maxName = len(i.Name)
 		}
 	}
-	suppliedParams := paramsAsMap(execParams(ex))
+	supplied := planshared.ParamsAsMap(suppliedParams)
 	for _, i := range inputs {
 		detail := ""
 		switch i.ResolvedVia {
 		case models.PlansInputResolvedViaCallerSecret:
 			detail = i.SecretName
 		case models.PlansInputResolvedViaLiteral:
-			if v, ok := suppliedParams[i.Name]; ok {
-				detail = formatValue(v)
+			if v, ok := supplied[i.Name]; ok {
+				detail = planshared.FormatValue(v)
 			}
 		case models.PlansInputResolvedViaDefault:
 			if p := findPlanParam(planSpec, i.Name); p != nil && p.Default != nil {
-				detail = formatValue(p.Default)
+				detail = planshared.FormatValue(p.Default)
 			}
 		}
-		printInputLine(out, "  ", maxName, i.Name, detail, planLevelVia(i.ResolvedVia))
+		planshared.PrintInputLine(out, "  ", maxName, i.Name, detail, planLevelVia(i.ResolvedVia))
 	}
 }
 
@@ -242,7 +246,7 @@ func printSteps(out io.Writer, steps []*models.PlanStepStatus, planSpec *models.
 		}
 		fmt.Fprintf(out, "  %-*s   %s\n", maxID, s.ID, s.Phase)
 		if hasAction {
-			label := actionLabel(step.Action)
+			label := planshared.ActionLabel(step.Action)
 			if step.Action.Revision > 0 {
 				label += fmt.Sprintf("   (revision %d)", step.Action.Revision)
 			}
@@ -253,7 +257,7 @@ func printSteps(out io.Writer, steps []*models.PlanStepStatus, planSpec *models.
 		}
 		if len(s.Inputs) > 0 {
 			fmt.Fprintln(out, "    inputs:")
-			stepValues := paramsAsMap(stepArgsValues(step))
+			stepValues := planshared.ParamsAsMap(planshared.StepArgsValues(step))
 			maxName := 0
 			for _, in := range s.Inputs {
 				if len(in.Name) > maxName {
@@ -267,14 +271,14 @@ func printSteps(out io.Writer, steps []*models.PlanStepStatus, planSpec *models.
 					detail = in.Ref
 				case models.PlansInputResolvedViaLiteral:
 					if v, ok := stepValues[in.Name]; ok {
-						detail = formatValue(v)
+						detail = planshared.FormatValue(v)
 					}
 				case models.PlansInputResolvedViaDefault:
 					if p := findStepInputDecl(step, in.Name); p != nil && p.Default != nil {
-						detail = formatValue(p.Default)
+						detail = planshared.FormatValue(p.Default)
 					}
 				}
-				printInputLine(out, "      ", maxName, in.Name, detail, stepLevelVia(in.ResolvedVia))
+				planshared.PrintInputLine(out, "      ", maxName, in.Name, detail, stepLevelVia(in.ResolvedVia))
 			}
 		}
 		if len(s.Outputs) > 0 {
@@ -299,111 +303,6 @@ func hasStepBody(s *models.PlanStepStatus) bool {
 	return len(s.Inputs) > 0 || len(s.Outputs) > 0 || s.Error != ""
 }
 
-// actionLabel renders the step's action as "name (id)" when the
-// server returns both, name alone when the ID is empty, or ID alone
-// when the name isn't populated yet (older plans compiled before the
-// Name field was added).
-func actionLabel(a *models.PlanStepAction) string {
-	if a == nil {
-		return ""
-	}
-	if a.Name == "" {
-		return a.ActionID
-	}
-	if a.ActionID == "" {
-		return a.Name
-	}
-	return fmt.Sprintf("%s (%s)", a.Name, a.ActionID)
-}
-
-// printInputLine emits one input row in the form
-//
-//	<indent><name padded>   ← <detail>   (<via>)
-//
-// or, when there's no detail to show:
-//
-//	<indent><name padded>   (<via>)
-//
-// Manual padding is used (rather than tabwriter) because rows with
-// and without a detail cell have different "shapes"; a single
-// tabwriter scope would size the empty middle column based on the
-// longest detail and leave the (via) tag for no-detail rows pushed
-// far to the right.
-func printInputLine(out io.Writer, indent string, nameWidth int, name, detail, via string) {
-	if detail == "" {
-		fmt.Fprintf(out, "%s%-*s   (%s)\n", indent, nameWidth, name, via)
-		return
-	}
-	fmt.Fprintf(out, "%s%-*s   ← %s   (%s)\n", indent, nameWidth, name, detail, via)
-}
-
-// formatValue renders a parameter value for a detail column. Strings
-// pass through as bare text; everything else round-trips through JSON
-// so objects/arrays stay copy-pasteable into a plan spec rather than
-// rendering as Go's map[a:1] / [1 2] forms. Multi-line and very long
-// values are summarised so they don't break the inline arrow form;
-// users who want the full value can use -o yaml.
-func formatValue(v any) string {
-	if v == nil {
-		return ""
-	}
-	var raw string
-	if s, ok := v.(string); ok {
-		raw = s
-	} else {
-		b, err := json.Marshal(v)
-		if err != nil {
-			return fmt.Sprintf("%v", v)
-		}
-		raw = string(b)
-	}
-	return truncateForDisplay(raw)
-}
-
-// maxValueDisplay caps single-line value rendering. Keeps room on a
-// 100-column terminal for the indent + name + arrow + via tag
-// surrounding the value.
-const maxValueDisplay = 80
-
-// truncateForDisplay collapses a value into a single line suitable
-// for the inline arrow form. Multi-line values are reduced to the
-// first line + a (N lines) marker; over-long single lines get a
-// trailing ellipsis.
-func truncateForDisplay(s string) string {
-	trimmed := strings.TrimRight(s, "\n")
-	if firstLine, _, multiline := strings.Cut(trimmed, "\n"); multiline {
-		nLines := strings.Count(trimmed, "\n") + 1
-		if len(firstLine) > maxValueDisplay {
-			firstLine = firstLine[:maxValueDisplay]
-		}
-		return fmt.Sprintf("%s… (%d lines)", firstLine, nLines)
-	}
-	if len(trimmed) > maxValueDisplay {
-		return trimmed[:maxValueDisplay] + "…"
-	}
-	return trimmed
-}
-
-func execParams(ex *models.PlanExecution) any {
-	if ex == nil || ex.Spec == nil {
-		return nil
-	}
-	return ex.Spec.Params
-}
-
-func stepArgsValues(step *models.PlanStep) any {
-	if step == nil || step.Args == nil {
-		return nil
-	}
-	return step.Args.Values
-}
-
-func paramsAsMap(v any) map[string]any {
-	if m, ok := v.(map[string]any); ok {
-		return m
-	}
-	return nil
-}
 
 func findPlanParam(planSpec *models.PlanSpec, name string) *models.PlanField {
 	if planSpec == nil {

--- a/internal/command/planexec/printers.go
+++ b/internal/command/planexec/printers.go
@@ -4,13 +4,11 @@ import (
 	"fmt"
 	"io"
 	"text/tabwriter"
-	"time"
 
 	"github.com/docker/go-units"
 	"github.com/signadot/cli/internal/sdtab"
 	"github.com/signadot/cli/internal/utils"
 	"github.com/signadot/go-sdk/models"
-	"github.com/xeonx/timeago"
 )
 
 // PrintRunResult prints execution details with output summary for plan run.
@@ -88,32 +86,85 @@ func printExecDetails(out io.Writer, ex *models.PlanExecution) error {
 		return err
 	}
 
-	// Print step status table if steps are present.
+	if ex.Status != nil && len(ex.Status.Inputs) > 0 {
+		fmt.Fprintln(out)
+		fmt.Fprintln(out, "Inputs:")
+		printPlanInputs(out, ex.Status.Inputs)
+	}
+
 	if ex.Status != nil && len(ex.Status.Steps) > 0 {
 		fmt.Fprintln(out)
-		return printStepTable(out, ex.Status.Steps)
+		fmt.Fprintln(out, "Steps:")
+		printSteps(out, ex.Status.Steps)
 	}
 
 	return nil
 }
 
-type stepRow struct {
-	ID    string `sdtab:"STEP"`
-	Phase string `sdtab:"PHASE"`
-	Error string `sdtab:"ERROR,trunc"`
+// isInterestingInput reports whether an input's resolution mechanism is
+// worth showing in the per-step detail. Pure literal/default/unbound
+// resolutions are noise; refs and secret-backed inputs are the
+// actionable cases. Unknown enum values are treated as interesting so
+// a server-side schema addition surfaces rather than getting silently
+// filtered.
+func isInterestingInput(via models.PlansInputResolvedVia) bool {
+	switch via {
+	case models.PlansInputResolvedViaLiteral,
+		models.PlansInputResolvedViaDefault,
+		models.PlansInputResolvedViaUnbound:
+		return false
+	}
+	return true
 }
 
-func printStepTable(out io.Writer, steps []*models.PlanStepStatus) error {
-	t := sdtab.New[stepRow](out)
-	t.AddHeader()
-	for _, s := range steps {
-		t.AddRow(stepRow{
-			ID:    s.ID,
-			Phase: string(s.Phase),
-			Error: s.Error,
-		})
+// printPlanInputs prints plan-level params in the indented arrow form
+// used throughout the steps section. All plan-level inputs are shown
+// (including literal/default/unbound) since this is the authoritative
+// view of what bound at dispatch time.
+func printPlanInputs(out io.Writer, inputs []*models.PlanInputStatus) {
+	tw := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
+	for _, i := range inputs {
+		detail := ""
+		if i.SecretName != "" {
+			detail = i.SecretName
+		}
+		printInputLine(tw, "  ", i.Name, detail, string(i.ResolvedVia))
 	}
-	return t.Flush()
+	tw.Flush()
+}
+
+func printSteps(out io.Writer, steps []*models.PlanStepStatus) {
+	tw := tabwriter.NewWriter(out, 0, 0, 3, ' ', 0)
+	for _, s := range steps {
+		fmt.Fprintf(tw, "  %s\t%s\n", s.ID, s.Phase)
+		if s.Error != "" {
+			fmt.Fprintf(tw, "      error:\t%s\n", s.Error)
+		}
+		for _, i := range s.Inputs {
+			if !isInterestingInput(i.ResolvedVia) {
+				continue
+			}
+			printInputLine(tw, "      ", i.Name, i.Ref, string(i.ResolvedVia))
+		}
+	}
+	tw.Flush()
+}
+
+// printInputLine emits one input row in the form
+//
+//	<indent><name>  ←  <detail>  (<via>)
+//
+// or, when there's no detail to show:
+//
+//	<indent><name>  (<via>)
+//
+// Tab stops keep the arrows aligned within a single tabwriter scope.
+func printInputLine(tw io.Writer, indent, name, detail, via string) {
+	if detail == "" {
+		fmt.Fprintf(tw, "%s%s\t\t(%s)\n", indent, name, via)
+		return
+	}
+	fmt.Fprintf(tw, "%s%s\t← %s\t(%s)\n", indent, name, detail, via)
 }
 
 type outputRow struct {
@@ -185,8 +236,8 @@ func printAllOutputsTable(out io.Writer, outputs []allOutput) error {
 			Step:    o.Step,
 			Scope:   o.Scope,
 			Storage: o.Type,
-			Size:  size,
-			Ready: ready,
+			Size:    size,
+			Ready:   ready,
 		})
 	}
 	return t.Flush()
@@ -214,11 +265,7 @@ func printExecTable(out io.Writer, results []*models.PlanExecutionQueryResult) e
 				total := sc.Init + sc.Waiting + sc.Running + sc.Completed + sc.Failed + sc.Skipped
 				steps = fmt.Sprintf("%d/%d", sc.Completed, total)
 			}
-			if r.Status.CreatedAt != "" {
-				if ts, err := time.Parse(time.RFC3339, r.Status.CreatedAt); err == nil {
-					created = timeago.NoMax(timeago.English).Format(ts)
-				}
-			}
+			created = utils.TimeAgo(r.Status.CreatedAt)
 		}
 		t.AddRow(execRow{
 			ID:      r.ID,

--- a/internal/command/planexec/printers.go
+++ b/internal/command/planexec/printers.go
@@ -182,12 +182,19 @@ func printSteps(out io.Writer, steps []*models.PlanStepStatus, planSpec *models.
 		}
 	}
 	for i, s := range steps {
-		if i > 0 && hasStepBody(s) {
+		step := findStep(planSpec, s.ID)
+		hasAction := step != nil && step.Action != nil
+		hasBody := hasStepBody(s) || hasAction
+		if i > 0 && hasBody {
 			fmt.Fprintln(out)
 		}
 		fmt.Fprintf(out, "  %-*s   %s\n", maxID, s.ID, s.Phase)
-		if !hasStepBody(s) {
-			continue
+		if hasAction {
+			label := actionLabel(step.Action)
+			if step.Action.Revision > 0 {
+				label += fmt.Sprintf("   (revision %d)", step.Action.Revision)
+			}
+			fmt.Fprintf(out, "    action: %s\n", label)
 		}
 		if s.Error != "" {
 			fmt.Fprintf(out, "    error: %s\n", s.Error)
@@ -196,7 +203,6 @@ func printSteps(out io.Writer, steps []*models.PlanStepStatus, planSpec *models.
 			continue
 		}
 		fmt.Fprintln(out, "    inputs:")
-		step := findStep(planSpec, s.ID)
 		stepValues := paramsAsMap(stepArgsValues(step))
 		maxName := 0
 		for _, in := range s.Inputs {
@@ -225,6 +231,23 @@ func printSteps(out io.Writer, steps []*models.PlanStepStatus, planSpec *models.
 
 func hasStepBody(s *models.PlanStepStatus) bool {
 	return len(s.Inputs) > 0 || s.Error != ""
+}
+
+// actionLabel renders the step's action as "name (id)" when the
+// server returns both, name alone when the ID is empty, or ID alone
+// when the name isn't populated yet (older plans compiled before the
+// Name field was added).
+func actionLabel(a *models.PlanStepAction) string {
+	if a == nil {
+		return ""
+	}
+	if a.Name == "" {
+		return a.ActionID
+	}
+	if a.ActionID == "" {
+		return a.Name
+	}
+	return fmt.Sprintf("%s (%s)", a.Name, a.ActionID)
 }
 
 // printInputLine emits one input row in the form

--- a/internal/command/planshared/render.go
+++ b/internal/command/planshared/render.go
@@ -1,0 +1,135 @@
+// Package planshared holds the rendering helpers used by the plan,
+// planaction, planexec, and plantag commands. The helpers render
+// inputs/outputs in a single arrow form and lean on the same value
+// truncation rules so the four detail views stay visually in sync.
+package planshared
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/signadot/go-sdk/models"
+)
+
+// MaxValueDisplay caps single-line value rendering. Keeps room on a
+// 100-column terminal for the indent + name + arrow + via tag
+// surrounding the value.
+const MaxValueDisplay = 80
+
+// PrintInputLine emits one row in the form
+//
+//	<indent><name padded>   ← <detail>   (<via>)
+//
+// or, when there's no detail to show:
+//
+//	<indent><name padded>   (<via>)
+//
+// Manual padding is used (rather than tabwriter) because rows with
+// and without a detail cell have different shapes; a single
+// tabwriter scope would size the empty middle column based on the
+// longest detail and leave the (via) tag for no-detail rows pushed
+// far to the right.
+func PrintInputLine(out io.Writer, indent string, nameWidth int, name, detail, via string) {
+	if detail == "" {
+		fmt.Fprintf(out, "%s%-*s   (%s)\n", indent, nameWidth, name, via)
+		return
+	}
+	fmt.Fprintf(out, "%s%-*s   ← %s   (%s)\n", indent, nameWidth, name, detail, via)
+}
+
+// FormatValue renders a parameter value for a detail column. Strings
+// pass through as bare text; everything else round-trips through JSON
+// so objects/arrays stay copy-pasteable into a plan spec rather than
+// rendering as Go's map[a:1] / [1 2] forms. Multi-line and very long
+// values are summarised so they don't break the inline arrow form;
+// users who want the full value can use -o yaml.
+func FormatValue(v any) string {
+	if v == nil {
+		return ""
+	}
+	var raw string
+	if s, ok := v.(string); ok {
+		raw = s
+	} else {
+		b, err := json.Marshal(v)
+		if err != nil {
+			return fmt.Sprintf("%v", v)
+		}
+		raw = string(b)
+	}
+	return truncateForDisplay(raw)
+}
+
+// truncateForDisplay collapses a value into a single line suitable
+// for the inline arrow form. Multi-line values are reduced to the
+// first line + a (N lines) marker; over-long single lines get a
+// trailing ellipsis.
+func truncateForDisplay(s string) string {
+	trimmed := strings.TrimRight(s, "\n")
+	if firstLine, _, multiline := strings.Cut(trimmed, "\n"); multiline {
+		nLines := strings.Count(trimmed, "\n") + 1
+		if len(firstLine) > MaxValueDisplay {
+			firstLine = firstLine[:MaxValueDisplay]
+		}
+		return fmt.Sprintf("%s… (%d lines)", firstLine, nLines)
+	}
+	if len(trimmed) > MaxValueDisplay {
+		return trimmed[:MaxValueDisplay] + "…"
+	}
+	return trimmed
+}
+
+// FormatImage renders a PlanImageRef for the "image:" line. Returns
+// the literal image when set, "(from input \"name\")" when the image
+// is bound to an input, or empty when nothing is declared.
+func FormatImage(ref *models.PlanImageRef) string {
+	if ref == nil {
+		return ""
+	}
+	if ref.Literal != "" {
+		return ref.Literal
+	}
+	if ref.InputName != "" {
+		return fmt.Sprintf("(from input %q)", ref.InputName)
+	}
+	return ""
+}
+
+// ActionLabel renders the step's action as "name (id)" when the
+// server returns both, name alone when the ID is empty, or ID alone
+// when the name isn't populated yet (older plans compiled before the
+// Name field was added).
+func ActionLabel(a *models.PlanStepAction) string {
+	if a == nil {
+		return ""
+	}
+	if a.Name == "" {
+		return a.ActionID
+	}
+	if a.ActionID == "" {
+		return a.Name
+	}
+	return fmt.Sprintf("%s (%s)", a.Name, a.ActionID)
+}
+
+// ParamsAsMap returns the typical map[string]any shape of a
+// PlanArgs.Values / PlanExecutionSpec.Params field, or nil if the
+// untyped any is missing or shaped differently. Callers use it to
+// look up step or plan-level literal values by name.
+func ParamsAsMap(v any) map[string]any {
+	if m, ok := v.(map[string]any); ok {
+		return m
+	}
+	return nil
+}
+
+// StepArgsValues returns the literal values map declared on a step,
+// nil-safe through both the step and its Args.
+func StepArgsValues(s *models.PlanStep) any {
+	if s == nil || s.Args == nil {
+		return nil
+	}
+	return s.Args.Values
+}

--- a/internal/command/plantag/printers.go
+++ b/internal/command/plantag/printers.go
@@ -17,7 +17,7 @@ type tagRow struct {
 	Name    string `sdtab:"NAME"`
 	PlanID  string `sdtab:"PLAN ID"`
 	Steps   string `sdtab:"STEPS"`
-	Prompt  string `sdtab:"PROMPT"`
+	Hint    string `sdtab:"SELECTION HINT"`
 	Created string `sdtab:"CREATED"`
 	Updated string `sdtab:"UPDATED"`
 }
@@ -26,31 +26,23 @@ func printTagTable(out io.Writer, tags []*models.PlanTag) error {
 	t := sdtab.New[tagRow](out)
 	t.AddHeader()
 	for _, tag := range tags {
-		var planID, steps, prompt, created, updated string
+		var planID, steps, hint, created, updated string
 		if tag.Spec != nil {
 			planID = tag.Spec.PlanID
 		}
 		if tag.Plan != nil && tag.Plan.Spec != nil {
 			steps = fmt.Sprintf("%d", len(tag.Plan.Spec.Steps))
-			prompt = print.FirstLine(tag.Plan.Spec.Prompt)
+			hint = print.FirstLine(tag.Plan.Spec.SelectionHint)
 		}
 		if tag.Status != nil {
-			if tag.Status.CreatedAt != "" {
-				if ts, err := time.Parse(time.RFC3339, tag.Status.CreatedAt); err == nil {
-					created = timeago.NoMax(timeago.English).Format(ts)
-				}
-			}
-			if tag.Status.UpdatedAt != "" {
-				if ts, err := time.Parse(time.RFC3339, tag.Status.UpdatedAt); err == nil {
-					updated = timeago.NoMax(timeago.English).Format(ts)
-				}
-			}
+			created = utils.TimeAgo(tag.Status.CreatedAt)
+			updated = utils.TimeAgo(tag.Status.UpdatedAt)
 		}
 		t.AddRow(tagRow{
 			Name:    tag.Name,
 			PlanID:  planID,
 			Steps:   steps,
-			Prompt:  prompt,
+			Hint:    hint,
 			Created: created,
 			Updated: updated,
 		})

--- a/internal/command/plantag/printers.go
+++ b/internal/command/plantag/printers.go
@@ -4,13 +4,11 @@ import (
 	"fmt"
 	"io"
 	"text/tabwriter"
-	"time"
 
 	"github.com/signadot/cli/internal/print"
 	"github.com/signadot/cli/internal/sdtab"
 	"github.com/signadot/cli/internal/utils"
 	"github.com/signadot/go-sdk/models"
-	"github.com/xeonx/timeago"
 )
 
 type tagRow struct {
@@ -106,21 +104,13 @@ func printHistoryTable(out io.Writer, history []*models.TagMapping) error {
 	t := sdtab.New[historyRow](out)
 	t.AddHeader()
 	for _, h := range history {
-		tagged := ""
-		if h.TaggedAt != "" {
-			if ts, err := time.Parse(time.RFC3339, h.TaggedAt); err == nil {
-				tagged = timeago.NoMax(timeago.English).Format(ts)
-			}
-		}
 		untagged := "(current)"
 		if h.UntaggedAt != "" {
-			if ts, err := time.Parse(time.RFC3339, h.UntaggedAt); err == nil {
-				untagged = timeago.NoMax(timeago.English).Format(ts)
-			}
+			untagged = utils.TimeAgo(h.UntaggedAt)
 		}
 		t.AddRow(historyRow{
-			PlanID:    h.PlanID,
-			TaggedAt:  tagged,
+			PlanID:     h.PlanID,
+			TaggedAt:   utils.TimeAgo(h.TaggedAt),
 			UntaggedAt: untagged,
 		})
 	}

--- a/internal/config/plan.go
+++ b/internal/config/plan.go
@@ -10,14 +10,16 @@ type PlanCompile struct {
 	*Plan
 
 	// Flags
-	Filename string
-	Tag      string
+	Filename      string
+	Tag           string
+	SelectionHint string
 }
 
 func (c *PlanCompile) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&c.Filename, "filename", "f", "", "file containing the prompt to compile")
 	cmd.MarkFlagRequired("filename")
 	cmd.Flags().StringVar(&c.Tag, "tag", "", "tag the compiled plan with this name")
+	cmd.Flags().StringVar(&c.SelectionHint, "selection-hint", "", "short description shown in plan tag list (helps pick a plan)")
 }
 
 type PlanCreate struct {

--- a/internal/print/attach.go
+++ b/internal/print/attach.go
@@ -7,20 +7,30 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/docker/go-units"
 )
 
 // AttachEvent represents a structured event emitted during --attach mode.
 type AttachEvent struct {
 	Time   time.Time `json:"time"`
 	Type   string    `json:"type"`             // "log", "output", "result"
-	Step   string    `json:"step,omitempty"`   // for log events
+	Step   string    `json:"step,omitempty"`   // for log events; for output events, the step that produced a plan-level output
 	Stream string    `json:"stream,omitempty"` // "stdout" or "stderr", for log events
 	Msg    string    `json:"msg,omitempty"`    // for log events
 	Name   string    `json:"name,omitempty"`   // for output events
-	Value  any       `json:"value,omitempty"`  // for output events
-	ID     string    `json:"id,omitempty"`     // for result events
-	Phase  string    `json:"phase,omitempty"`  // for result events
-	Error  string    `json:"error,omitempty"`  // for result events (if failed)
+
+	// For output events:
+	Kind        string `json:"kind,omitempty"`        // "inline" | "artifact"
+	Value       any    `json:"value,omitempty"`       // present for inline outputs
+	Size        int64  `json:"size,omitempty"`        // bytes, for artifact outputs
+	Ready       *bool  `json:"ready,omitempty"`       // for artifact outputs (always set when Kind=artifact)
+	ContentType string `json:"contentType,omitempty"` // for artifact outputs, when metadata.contentType is set
+
+	ID     string `json:"id,omitempty"`     // for created/result events: the execution ID
+	PlanID string `json:"planID,omitempty"` // for created events: the source plan
+	Phase  string `json:"phase,omitempty"`  // for result events
+	Error  string `json:"error,omitempty"`  // for result events (if failed); for output events, an artifact-side error
 }
 
 // AttachWriter writes structured events to an io.Writer in either
@@ -71,7 +81,37 @@ func formatText(e AttachEvent) string {
 		fmt.Fprintf(&b, " msg=%s", quoteIfNeeded(strings.TrimRight(e.Msg, "\n")))
 	case "output":
 		fmt.Fprintf(&b, " name=%s", e.Name)
-		fmt.Fprintf(&b, " value=%s", quoteIfNeeded(fmt.Sprint(e.Value)))
+		if e.Step != "" {
+			fmt.Fprintf(&b, " step=%s", e.Step)
+		}
+		switch e.Kind {
+		case "artifact":
+			fmt.Fprintf(&b, " kind=artifact")
+			if e.Size > 0 {
+				fmt.Fprintf(&b, " size=%s", units.HumanSize(float64(e.Size)))
+			}
+			if e.Ready != nil {
+				fmt.Fprintf(&b, " ready=%t", *e.Ready)
+			}
+			if e.ContentType != "" {
+				fmt.Fprintf(&b, " content_type=%s", e.ContentType)
+			}
+			if e.Error != "" {
+				fmt.Fprintf(&b, " error=%s", quoteIfNeeded(e.Error))
+			}
+		case "inline":
+			fmt.Fprintf(&b, " kind=inline")
+			fmt.Fprintf(&b, " value=%s", quoteIfNeeded(fmt.Sprint(e.Value)))
+		default:
+			// Older emit sites that didn't set Kind: keep the legacy
+			// value=<...> shape so existing log consumers don't break.
+			fmt.Fprintf(&b, " value=%s", quoteIfNeeded(fmt.Sprint(e.Value)))
+		}
+	case "created":
+		fmt.Fprintf(&b, " id=%s", e.ID)
+		if e.PlanID != "" {
+			fmt.Fprintf(&b, " plan_id=%s", e.PlanID)
+		}
 	case "result":
 		fmt.Fprintf(&b, " id=%s", e.ID)
 		fmt.Fprintf(&b, " phase=%s", e.Phase)

--- a/internal/utils/time.go
+++ b/internal/utils/time.go
@@ -20,6 +20,17 @@ func FormatTimestamp(in string) string {
 	return fmt.Sprintf("%s (%s ago)", local, elapsed)
 }
 
+// TimeAgo returns just the relative form ("4 days ago") for an RFC3339
+// timestamp, suitable for compact table columns. Returns the input
+// unchanged if it can't be parsed.
+func TimeAgo(in string) string {
+	t, err := time.Parse(time.RFC3339, in)
+	if err != nil {
+		return in
+	}
+	return timeago.NoMax(timeago.English).Format(t)
+}
+
 func GetTTLTimeAgoFromBase(baseTime time.Time, dur string) string {
 	n := len(dur)
 	count, unit := dur[0:n-1], dur[n-1:]


### PR DESCRIPTION
Stacked on #325.

## Summary

- Replaces the flat STEP/PHASE/ERROR table in `plan x get` with a nested per-step layout that keeps inputs and errors visually owned by the step they belong to. Per-step inputs surface refs and secret-backed bindings; pure literal/default/unbound inputs are filtered as noise.
- Adds a plan-level `Inputs:` section in the same arrow/via form. Useful for confirming which `--param-secret` bindings actually took effect at dispatch time.
- Adds `utils.TimeAgo` for the compact \"X ago\" form (the existing `FormatTimestamp` gives the verbose absolute+relative form, too wide for table columns), and uses it in `plan x list`. Several other printers inline the same `time.Parse + timeago.NoMax` pattern; migrating those is left for a separate cleanup.

## Examples

Step ref (data flow between steps):

```
Steps:
  send_request   completed
  check_status   completed
      capture    ← steps.send_request.outputs.capture   (ref)
```

Plan-level params with literal + unbound:

```
Inputs:
  present_param    (literal)
  unbound_param    (unbound)

Steps:
  step_a   completed
  step_b   completed
```

`--param-secret` binding + step failure (error nested under the failing step):

```
Inputs:
  region  ← test-input-secret  (callerSecret)

Steps:
  echo_region   failed
      error:    extra_output \"got_region\" declares a schema but the script wrote to got_region instead of got_region.json — use the .json extension for typed outputs
```

## Test plan

- [ ] `plan x get <id>` for an exec with no params shows no `Inputs:` section, just the nested steps
- [ ] `plan x get <id>` for an exec with `--param-secret` shows the `callerSecret` row with the bound secret name
- [ ] `plan x get <id>` for an exec with a step that refs another step's output shows the ref expression text under the consuming step
- [ ] `plan x get <id>` for a failed exec shows the step error nested under the failed step
- [ ] `plan x list` still shows the compact \"X ago\" form in the CREATED column
- [ ] Step inputs with only literal/default/unbound resolutions don't add visual noise