### PR TITLE
Add hidden plan schema command for agents

### DIFF
--- a/internal/command/plan/command.go
+++ b/internal/command/plan/command.go
@@ -23,6 +23,7 @@ func New(api *config.API) *cobra.Command {
 		newGet(cfg),
 		newDelete(cfg),
 		newRecompile(cfg),
+		newSchema(cfg),
 		plantag.New(cfg),
 		planexec.New(cfg),
 		planaction.New(cfg),

--- a/internal/command/plan/schema.go
+++ b/internal/command/plan/schema.go
@@ -1,0 +1,45 @@
+package plan
+
+import (
+	"encoding/json"
+	"io"
+
+	"github.com/signadot/cli/internal/config"
+	sdkmeta "github.com/signadot/go-sdk/client/meta"
+	"github.com/spf13/cobra"
+)
+
+func newSchema(plan *config.Plan) *cobra.Command {
+	cfg := &config.PlanSchema{Plan: plan}
+
+	cmd := &cobra.Command{
+		Use:    "schema",
+		Short:  "Print the plan-authoring JSON Schema (machine-readable)",
+		Args:   cobra.NoArgs,
+		Hidden: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runSchema(cfg, cmd.OutOrStdout())
+		},
+	}
+
+	return cmd
+}
+
+func runSchema(cfg *config.PlanSchema, out io.Writer) error {
+	if err := cfg.InitAPIConfig(); err != nil {
+		return err
+	}
+	resp, err := cfg.Client.Meta.MetaPlans(sdkmeta.NewMetaPlansParams())
+	if err != nil {
+		return err
+	}
+	b, err := json.Marshal(resp.Payload)
+	if err != nil {
+		return err
+	}
+	if _, err := out.Write(b); err != nil {
+		return err
+	}
+	_, err = out.Write([]byte("\n"))
+	return err
+}

--- a/internal/config/plan.go
+++ b/internal/config/plan.go
@@ -54,3 +54,7 @@ func (c *PlanRecompile) AddFlags(cmd *cobra.Command) {
 type PlanDelete struct {
 	*Plan
 }
+
+type PlanSchema struct {
+	*Plan
+}


### PR DESCRIPTION
## Summary
- Adds `signadot plan schema`, a hidden subcommand that prints the plan-authoring JSON Schema to stdout.
- Calls the SDK's `Meta.MetaPlans` (`GET /meta/plans`) and writes the response payload as compact JSON with a trailing newline.
- Intended for agents authoring plan specs; output is fixed JSON (no `-o` flag, no other flags).

## Test plan
- [ ] `signadot plan schema` prints valid JSON to stdout
- [ ] Piping through `jq` works: `signadot plan schema | jq .`
- [ ] Command is hidden from `signadot plan --help`
- [ ] `signadot plan schema --help` still works (shows usage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)