### PR TITLE
plan run --attach: resolve drill-in outputs and render values as JSON

### DIFF
--- a/internal/command/plan/run.go
+++ b/internal/command/plan/run.go
@@ -1,6 +1,7 @@
 package plan
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -20,8 +21,8 @@ import (
 	sdkclient "github.com/signadot/go-sdk/client"
 	planlogs "github.com/signadot/go-sdk/client/plan_execution_logs"
 	planexecs "github.com/signadot/go-sdk/client/plan_executions"
-	sdkplans "github.com/signadot/go-sdk/client/plans"
 	plantags "github.com/signadot/go-sdk/client/plan_tags"
+	sdkplans "github.com/signadot/go-sdk/client/plans"
 	"github.com/signadot/go-sdk/models"
 	"github.com/spf13/cobra"
 )
@@ -443,6 +444,14 @@ func attachExecution(ctx context.Context, cfg *config.PlanRun, out, log io.Write
 			ex := resp.Payload
 			// Emit output events for resolved plan-level outputs.
 			if ex.Status != nil {
+				// Drill-in outputs and artifact-backed whole outputs leave
+				// PlanOutputStatus.Value nil — the runner records the ref
+				// + drill path but doesn't materialize the resolved value
+				// until something asks for it via GetPlanExecutionOutput.
+				// Fill them in now so attach streams the actual values
+				// instead of nil. Best-effort: fetch failures are logged
+				// but don't abort the stream.
+				resolveAttachOutputs(cfg, log, ex.ID, ex.Status.Outputs)
 				for _, o := range ex.Status.Outputs {
 					aw.Emit(sdkprint.AttachEvent{
 						Type:  "output",
@@ -483,6 +492,61 @@ func writeRunOutput(cfg *config.PlanRun, out io.Writer, exec *models.PlanExecuti
 		return sdkprint.RawYAML(out, exec)
 	default:
 		return planexec.PrintRunResult(out, exec)
+	}
+}
+
+// resolveAttachOutputs fills in PlanOutputStatus.Value for any outputs
+// the server didn't materialize inline. The runner records drill-in
+// outputs and artifact-backed whole outputs without populating Value;
+// the resolved bytes come from GetPlanExecutionOutput at serve time.
+// Mutates outputs in place. Best-effort: per-output errors are logged
+// to log and the corresponding Value stays nil rather than aborting
+// the whole attach stream.
+func resolveAttachOutputs(cfg *config.PlanRun, log io.Writer, execID string, outputs []*models.PlanOutputStatus) {
+	needsFetch := false
+	for _, o := range outputs {
+		if o != nil && o.Value == nil {
+			needsFetch = true
+			break
+		}
+	}
+	if !needsFetch {
+		return
+	}
+
+	transportCfg := cfg.GetBaseTransport()
+	transportCfg.OverrideConsumers = true
+	transportCfg.Consumers = map[string]runtime.Consumer{
+		"*/*": runtime.ByteStreamConsumer(),
+	}
+	err := cfg.APIClientWithCustomTransport(transportCfg,
+		func(c *sdkclient.SignadotAPI) error {
+			for _, o := range outputs {
+				if o == nil || o.Value != nil {
+					continue
+				}
+				var buf bytes.Buffer
+				params := planexecs.NewGetPlanExecutionOutputParams().
+					WithOrgName(cfg.Org).
+					WithExecutionID(execID).
+					WithOutputName(o.Name)
+				if _, _, err := c.PlanExecutions.GetPlanExecutionOutput(params, nil, &buf); err != nil {
+					fmt.Fprintf(log, "warning: resolving output %q for attach: %v\n", o.Name, err)
+					continue
+				}
+				var v any
+				if err := json.Unmarshal(buf.Bytes(), &v); err != nil {
+					// Non-JSON output (binary, plain text). Emit the raw
+					// bytes as a string so the stream still surfaces
+					// something meaningful.
+					v = buf.String()
+				}
+				o.Value = v
+			}
+			return nil
+		})
+	if err != nil {
+		fmt.Fprintf(log, "warning: resolving attach outputs: %v\n", err)
 	}
 }
 

--- a/internal/print/attach.go
+++ b/internal/print/attach.go
@@ -71,7 +71,7 @@ func formatText(e AttachEvent) string {
 		fmt.Fprintf(&b, " msg=%s", quoteIfNeeded(strings.TrimRight(e.Msg, "\n")))
 	case "output":
 		fmt.Fprintf(&b, " name=%s", e.Name)
-		fmt.Fprintf(&b, " value=%s", quoteIfNeeded(fmt.Sprint(e.Value)))
+		fmt.Fprintf(&b, " value=%s", quoteIfNeeded(formatAttachValue(e.Value)))
 	case "result":
 		fmt.Fprintf(&b, " id=%s", e.ID)
 		fmt.Fprintf(&b, " phase=%s", e.Phase)
@@ -81,6 +81,27 @@ func formatText(e AttachEvent) string {
 	}
 
 	return b.String()
+}
+
+// formatAttachValue renders an output value for the slog-style text
+// stream. Strings stay unquoted (the common case for plan outputs).
+// Structured values (maps, slices) are JSON-encoded so the reader
+// sees `{"check":"..."}` instead of Go's default `map[check:...]`.
+// nil renders as <nil> matching the prior behavior. Numbers and bools
+// render as their JSON forms (`200`, `true`).
+func formatAttachValue(v any) string {
+	switch x := v.(type) {
+	case nil:
+		return "<nil>"
+	case string:
+		return x
+	default:
+		b, err := json.Marshal(v)
+		if err != nil {
+			return fmt.Sprint(v)
+		}
+		return string(b)
+	}
 }
 
 func quoteIfNeeded(s string) string {

--- a/internal/print/attach_test.go
+++ b/internal/print/attach_test.go
@@ -1,0 +1,34 @@
+package print
+
+import "testing"
+
+func TestFormatAttachValue(t *testing.T) {
+	cases := []struct {
+		name string
+		in   any
+		want string
+	}{
+		{"nil", nil, "<nil>"},
+		{"string", "hello world", "hello world"},
+		{"empty string", "", ""},
+		// Numbers come back from JSON as float64; JSON marshal renders
+		// integral floats without a trailing decimal.
+		{"int-as-float64", float64(200), "200"},
+		{"true", true, "true"},
+		{"false", false, "false"},
+		{"map", map[string]any{"check": "frontend / returns 200"},
+			`{"check":"frontend / returns 200"}`},
+		{"slice", []any{"a", "b"}, `["a","b"]`},
+		{"nested", map[string]any{
+			"response": map[string]any{"statusCode": float64(200)},
+		}, `{"response":{"statusCode":200}}`},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := formatAttachValue(c.in)
+			if got != c.want {
+				t.Errorf("formatAttachValue(%#v) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Two related fixes to `plan run --attach` that improve the streamed output UX. Both are in the same code path — the end-of-execution output-event emission in \`internal/command/plan/run.go\`.

### 1. Drill-in (and artifact-backed) outputs streamed as \`value=<nil>\`

Plan-level outputs that drill into a JSON sub-field (e.g. \`steps.send.outputs.capture.response.statusCode\`) and outputs whose whole value lives in S3 leave \`PlanOutputStatus.Value\` nil. The runner deliberately records the ref + drill path without materializing the resolved value — the apiserver applies the drill at serve time inside \`GetPlanExecutionOutput\`. From the type comment:

> The drill is applied at download time by the apiserver — the runner records it but does not materialize the drilled value, so the source step's existing artifact (or inline Value) is reused without any extra upload.

The attach flow was reading \`o.Value\` directly, so every drill-in surfaced as \`value=<nil>\` while \`plan x get-output <exec> <name>\` returned the right value afterward. Same path for artifact-backed whole outputs (Value nil because the bytes live in S3).

**Fix:** at end of stream, for any output with nil Value, fetch the resolved bytes via \`GetPlanExecutionOutput\` and parse as JSON (or fall through to the raw string for non-JSON outputs). Best-effort — per-output fetch failures are logged to stderr but don't abort the stream, so worst case the behavior degrades to today's nil-emission.

### 2. Object-typed values rendered as Go's \`map[k:v]\` instead of JSON

With (1) fixed, any output that resolves to a map/slice was rendered via \`fmt.Sprint\`, producing \`map[check:frontend / returns 200]\` instead of structured JSON. Inconsistent with how a user reading the stream expects to see structured values.

**Fix:** new \`formatAttachValue\` helper. Strings stay unquoted (the common case for plan outputs); nil renders as \`<nil>\` matching prior behavior; everything else (numbers, bools, maps, slices) is JSON-marshaled. So \`{"check":"frontend / returns 200"}\` instead of \`map[check:...]\`, and \`200\` instead of \`200\` (already worked, but now via the same code path).

## Test plan

- [x] \`go build ./...\` clean.
- [x] \`go vet ./...\` clean.
- [x] \`gofmt -l\` clean.
- [x] \`go test ./internal/print/\` — new \`TestFormatAttachValue\` covers nil, string, empty string, number, bool, map, slice, nested object (9 cases, all pass).
- [ ] Manual repro against dev: run a plan with a drill-in output and an object-typed output via \`--attach\`; confirm the streamed \`value=\` for both (a) renders the resolved value rather than \`<nil>\`, and (b) renders the object as \`{"check":"..."}\` rather than \`map[check:...]\`. The plan from sandboxes investigation (\`steps.send_request.outputs.capture.response.statusCode\` + \`steps.assert_200.outputs.result\`) reproduces both fixes in one execution.

## Notes

- The resolution path (1) does N extra API calls at end-of-stream, where N = number of plan-level outputs whose Value was nil. Tiny in practice; bounded by the existing 1 MB drill-source cap.
- The \`--output-dir\` export path already calls \`GetPlanExecutionOutput\` per output; this generalizes the same pattern to attach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)