### PR TITLE
plan schema: honor -o flag, default to pretty JSON

### DIFF
--- a/internal/command/plan/schema.go
+++ b/internal/command/plan/schema.go
@@ -1,10 +1,11 @@
 package plan
 
 import (
-	"encoding/json"
+	"fmt"
 	"io"
 
 	"github.com/signadot/cli/internal/config"
+	"github.com/signadot/cli/internal/print"
 	sdkmeta "github.com/signadot/go-sdk/client/meta"
 	"github.com/spf13/cobra"
 )
@@ -33,13 +34,13 @@ func runSchema(cfg *config.PlanSchema, out io.Writer) error {
 	if err != nil {
 		return err
 	}
-	b, err := json.Marshal(resp.Payload)
-	if err != nil {
-		return err
+
+	switch cfg.OutputFormat {
+	case config.OutputFormatDefault, config.OutputFormatJSON:
+		return print.RawJSON(out, resp.Payload)
+	case config.OutputFormatYAML:
+		return print.RawYAML(out, resp.Payload)
+	default:
+		return fmt.Errorf("unsupported output format: %q", cfg.OutputFormat)
 	}
-	if _, err := out.Write(b); err != nil {
-		return err
-	}
-	_, err = out.Write([]byte("\n"))
-	return err
 }


### PR DESCRIPTION
## Summary
- `plan schema` previously ignored the global `-o`/`--output` flag and always emitted compact JSON.
- Switch to the standard `OutputFormatDefault`/`JSON`/`YAML` dispatch used elsewhere in the CLI (e.g. `secret get`).
- Default output is now pretty JSON (via `print.RawJSON`), making the schema human-readable out of the box. `-o yaml` is also supported.

## Test plan
- [x] `signadot plan schema` → pretty JSON
- [x] `signadot plan schema -o json` → pretty JSON
- [x] `signadot plan schema -o yaml` → YAML
- [x] `signadot plan schema -o xml` → rejected by the flag validator

🤖 Generated with [Claude Code](https://claude.com/claude-code)