### PR TITLE
devbox: self-heal stale cached ID on 404

### DIFF
--- a/internal/command/devbox/list.go
+++ b/internal/command/devbox/list.go
@@ -72,7 +72,17 @@ func list(cfg *config.DevboxList, out io.Writer, errOut io.Writer) error {
 		if !currentDevboxInList {
 			ddb, err := get(ctx, cfg, currentDevboxID)
 			if err != nil {
-				fmt.Fprintf(errOut, "Warning: Could not fetch devbox %s from ~/.signadot/.devbox-id: %v\n", currentDevboxID, err)
+				switch {
+				case devboxpkg.IsNotFound(err):
+					// Cached devbox no longer exists server-side (e.g. 30-day
+					// idle TTL). GetID self-heals on the next operation that
+					// needs it; here we just treat it as absent.
+					if cfg.Debug {
+						fmt.Fprintf(errOut, "debug: cached devbox %s is no longer registered\n", currentDevboxID)
+					}
+				default:
+					fmt.Fprintf(errOut, "Warning: Could not fetch devbox %s from ~/.signadot/.devbox-id: %v\n", currentDevboxID, err)
+				}
 				// set current to unknown
 				currentDevboxID = ""
 			} else {

--- a/internal/devbox/get_id.go
+++ b/internal/devbox/get_id.go
@@ -2,6 +2,7 @@ package devbox
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -13,7 +14,21 @@ import (
 	"github.com/signadot/cli/internal/utils/system"
 	"github.com/signadot/go-sdk/client/devboxes"
 	"github.com/signadot/go-sdk/models"
+	"github.com/signadot/go-sdk/transport"
 )
+
+// IsNotFound reports whether err represents a 404 response from the Signadot
+// API. Used to detect a cached devbox ID that the server has since deleted
+// (e.g. after the 30-day idle TTL). The SDK's transport middleware
+// (transport.FixAPIErrors) wraps every 4xx/5xx response in *transport.APIError
+// before the swagger reader sees it, so that is the type we unwrap to here.
+func IsNotFound(err error) bool {
+	var apiErr *transport.APIError
+	if errors.As(err, &apiErr) {
+		return apiErr.Code == http.StatusNotFound
+	}
+	return false
+}
 
 // ValidateDevboxID validates that a devbox ID exists and returns an error if it doesn't.
 func ValidateDevboxID(ctx context.Context, apiConfig *config.API, devboxID string) error {
@@ -66,17 +81,7 @@ func GetID(ctx context.Context, apiConfig *config.API, claim bool, name string) 
 	id := string(d)
 	if err != nil {
 		if os.IsNotExist(err) {
-			id, err := getIDByAPI(ctx, apiConfig, claim, name)
-			if err != nil {
-				return "", err
-			}
-			if err := system.CreateDirIfNotExist(filepath.Dir(file)); err != nil {
-				return "", err
-			}
-			if err := os.WriteFile(file, []byte(id), 0600); err != nil {
-				return "", err
-			}
-			return id, nil
+			return registerAndPersist(ctx, apiConfig, claim, name)
 		}
 		return "", err
 	}
@@ -91,6 +96,11 @@ func GetID(ctx context.Context, apiConfig *config.API, claim bool, name string) 
 
 		resp, err := apiConfig.Client.Devboxes.GetDevbox(params)
 		if err != nil {
+			if IsNotFound(err) {
+				// Cached devbox was deleted server-side (e.g. 30-day idle
+				// TTL). Drop the stale file and re-register.
+				return registerAndPersist(ctx, apiConfig, claim, name)
+			}
 			return "", err
 		}
 		if resp.Code() == http.StatusOK && resp.Payload != nil {
@@ -120,6 +130,31 @@ func GetID(ctx context.Context, apiConfig *config.API, claim bool, name string) 
 
 	_, err = apiConfig.Client.Devboxes.ClaimDevbox(params)
 	if err != nil {
+		if IsNotFound(err) {
+			// Cached devbox was deleted server-side; re-register (which also
+			// claims when claim=true).
+			return registerAndPersist(ctx, apiConfig, claim, name)
+		}
+		return "", err
+	}
+	return id, nil
+}
+
+// registerAndPersist registers a new devbox via the API and writes the resulting
+// ID to the cache file, replacing any prior contents.
+func registerAndPersist(ctx context.Context, apiConfig *config.API, claim bool, name string) (string, error) {
+	id, err := getIDByAPI(ctx, apiConfig, claim, name)
+	if err != nil {
+		return "", err
+	}
+	file, err := IDFile()
+	if err != nil {
+		return "", err
+	}
+	if err := system.CreateDirIfNotExist(filepath.Dir(file)); err != nil {
+		return "", err
+	}
+	if err := os.WriteFile(file, []byte(id), 0600); err != nil {
 		return "", err
 	}
 	return id, nil


### PR DESCRIPTION
## Summary
- `~/.signadot/.devbox-id` becomes stale when the server GCs an idle devbox (30-day TTL in `sandboxes/internal/control/devbox/constants.go`). Every subsequent CLI call then warns or fails with a 404.
- `devbox.GetID` now treats a 404 from `GetDevbox` or `ClaimDevbox` the same as a missing cache file: re-register and overwrite the file. Per-user devboxes recover transparently on the next `signadot local connect`.
- `devbox list` no longer prints the scary `404 Not Found: no such devbox …` warning when the cached ID is gone — it just omits the "current" row from the table. A `--debug` hint identifies the cleared id for troubleshooting.
- The explicit `signadot local connect --devbox <id>` path is **unchanged**: a user-supplied ID still errors hard on 404 rather than silently recreating.

Fixes signadot/community#136

### Behavior trade-off
There's a competing use case where a platform team pre-registers a userless devbox on a Remote Dev Environment so multiple users share that RDE's local-connect session slots. Under that pattern, a loud failure when the pre-provisioned devbox vanishes would arguably be preferable to silently recreating one. We accept the trade-off because RDE devboxes very rarely sit 30 days idle without use, and the per-user case is hit constantly. If this pattern grows, the right follow-up is a config knob or devbox-metadata marker to opt into strict (no-auto-recreate) behavior.

### Implementation notes
- New `devbox.IsNotFound(err)` predicate unwraps to `*transport.APIError` (not `*runtime.APIError`) — `transport.FixAPIErrors` middleware in the SDK wraps every 4xx/5xx before the swagger reader sees it.
- New unexported `registerAndPersist` helper centralizes the "register and write cache file" step, used both by the original file-not-exist path and the new 404-recovery sites.

## Test plan
Verified end-to-end against a local minikube + signadot install with apiserver backed by host MySQL:

- [x] Register a fresh devbox via `signadot devbox register`; confirm row in MySQL and matching `~/.signadot/.devbox-id`.
- [x] `DELETE FROM devboxes WHERE public_id=…;` to simulate the GC step.
- [x] `signadot devbox list` (no `--debug`): silent, no warning, table renders without the stale row.
- [x] `signadot --debug devbox list`: prints `debug: cached devbox <id> is no longer registered`.
- [x] `signadot local connect --unprivileged --wait=none --cluster=minikube`: completes silently; cache file rewritten with a fresh valid id; session claimed.
- [x] `go build ./...` and `go vet ./internal/devbox/... ./internal/command/devbox/... ./internal/command/local/...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)