### PR TITLE
bump libconnect for Dependabot vuln fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/oklog/run v1.1.0
 	github.com/panta/machineid v1.0.2
 	github.com/signadot/go-sdk v0.3.8-0.20260521222700-e386afcf25b5
-	github.com/signadot/libconnect v0.1.1-0.20260424105947-336dce43da75
+	github.com/signadot/libconnect v0.1.1-0.20260527182714-8667fac5519c
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/viper v1.11.0
 	github.com/theckman/yacspin v0.13.12

--- a/go.sum
+++ b/go.sum
@@ -456,8 +456,8 @@ github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
 github.com/signadot/go-sdk v0.3.8-0.20260521222700-e386afcf25b5 h1:k3SBmNm0VsniuO89/FOfEsIefbgSP/1MoKaECmz/xWg=
 github.com/signadot/go-sdk v0.3.8-0.20260521222700-e386afcf25b5/go.mod h1:l7XHS9snZXC+dy11NwXd1Ef+Z+K0SBhBUm4LAiFBbFU=
-github.com/signadot/libconnect v0.1.1-0.20260424105947-336dce43da75 h1:LZJrEqJeSb0CGsENOAQsvDeEO2YyMY1/ir2Nz4apvbI=
-github.com/signadot/libconnect v0.1.1-0.20260424105947-336dce43da75/go.mod h1:cAsgAummH9Q9DrLQ7+S3mqrBv/+ZYKVSEXjR/WfoUJM=
+github.com/signadot/libconnect v0.1.1-0.20260527182714-8667fac5519c h1:00Enauia0CJ7XVkdnifQ3+4O4phUZuaKa1Y0NRjiXUc=
+github.com/signadot/libconnect v0.1.1-0.20260527182714-8667fac5519c/go.mod h1:GkueqfFxRYG9iTCRD5kvF7miQ71F1xmD9vhUCUMdiKY=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/skeema/knownhosts v1.3.1 h1:X2osQ+RAjK76shCbvhHHHVl3ZlgDm8apHEHFqRjnBY8=
 github.com/skeema/knownhosts v1.3.1/go.mod h1:r7KTdC8l4uxWRyK2TpQZ/1o5HaSzh06ePQNxPwTcfiY=


### PR DESCRIPTION
## Summary

Bumps `github.com/signadot/libconnect` to pick up [signadot/libconnect#159](https://github.com/signadot/libconnect/pull/159), which updates libconnect's own dependencies to address Dependabot alerts:

- `google.golang.org/grpc` v1.78.0 → v1.79.3 — critical: authz bypass (CVE-2026-33186)
- `golang.org/x/net` v0.48.0 → v0.53.0
- `github.com/moby/spdystream` v0.5.0 → v0.5.1 — high: DoS on CRI (CVE-2026-35469)

The CLI already pinned these transitive deps at versions ≥ the post-fix versions, so the only `go.sum` change here is the libconnect pin itself. The point of the bump is to stop the upstream alerts from being reported against libconnect's own go.mod via this consumer.

## Test plan

- [ ] CI passes (build, unit tests)
- [ ] No surprises in `go.sum` diff — only the libconnect line changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)