### PR TITLE
bump libconnect to 31fdd26

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/oklog/run v1.1.0
 	github.com/panta/machineid v1.0.2
 	github.com/signadot/go-sdk v0.3.8-0.20260521222700-e386afcf25b5
-	github.com/signadot/libconnect v0.1.1-0.20260527182714-8667fac5519c
+	github.com/signadot/libconnect v0.1.1-0.20260527212426-31fdd269494f
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/viper v1.11.0
 	github.com/theckman/yacspin v0.13.12

--- a/go.sum
+++ b/go.sum
@@ -456,8 +456,8 @@ github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
 github.com/signadot/go-sdk v0.3.8-0.20260521222700-e386afcf25b5 h1:k3SBmNm0VsniuO89/FOfEsIefbgSP/1MoKaECmz/xWg=
 github.com/signadot/go-sdk v0.3.8-0.20260521222700-e386afcf25b5/go.mod h1:l7XHS9snZXC+dy11NwXd1Ef+Z+K0SBhBUm4LAiFBbFU=
-github.com/signadot/libconnect v0.1.1-0.20260527182714-8667fac5519c h1:00Enauia0CJ7XVkdnifQ3+4O4phUZuaKa1Y0NRjiXUc=
-github.com/signadot/libconnect v0.1.1-0.20260527182714-8667fac5519c/go.mod h1:GkueqfFxRYG9iTCRD5kvF7miQ71F1xmD9vhUCUMdiKY=
+github.com/signadot/libconnect v0.1.1-0.20260527212426-31fdd269494f h1:b8ZzCjMOat1IJ9Y5rTRoy7TjD0Ch/QDu8P5lHuSJoBQ=
+github.com/signadot/libconnect v0.1.1-0.20260527212426-31fdd269494f/go.mod h1:5/CHotq3FQnSv9XQUy3sQkJz240Al1MsJ2wm1wf3usE=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/skeema/knownhosts v1.3.1 h1:X2osQ+RAjK76shCbvhHHHVl3ZlgDm8apHEHFqRjnBY8=
 github.com/skeema/knownhosts v1.3.1/go.mod h1:r7KTdC8l4uxWRyK2TpQZ/1o5HaSzh06ePQNxPwTcfiY=


### PR DESCRIPTION
## Summary
- Bumps `github.com/signadot/libconnect` from `8667fac` to `31fdd26` (latest `main`).

### Upstream commits picked up
- [50c5ee8](https://github.com/signadot/libconnect/commit/50c5ee8) Bump go.opentelemetry.io/otel from 1.39.0 to 1.41.0

## Test plan
- [ ] CI build/test
- [x] Local `go build ./...` passes

Generated with [Claude Code](https://claude.com/claude-code)
