### PR TITLE
ENG-933: consume the ENG-933-regenerated go-sdk

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/nsf/jsondiff v0.0.0-20210926074059-1e845ec5d249
 	github.com/oklog/run v1.1.0
 	github.com/panta/machineid v1.0.2
-	github.com/signadot/go-sdk v0.3.8-0.20260616111829-cf476fc34600
+	github.com/signadot/go-sdk v0.3.8-0.20260616140141-c7f267f6836e
 	github.com/signadot/libconnect v0.1.1-0.20260527212426-31fdd269494f
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/viper v1.11.0
@@ -172,7 +172,7 @@ require (
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 	gopkg.in/yaml.v2 v2.4.0
-	gopkg.in/yaml.v3 v3.0.1 // indirect
+	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.33.0
 	k8s.io/apimachinery v0.33.0
 	k8s.io/klog/v2 v2.130.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/nsf/jsondiff v0.0.0-20210926074059-1e845ec5d249
 	github.com/oklog/run v1.1.0
 	github.com/panta/machineid v1.0.2
-	github.com/signadot/go-sdk v0.3.8-0.20260616140141-c7f267f6836e
+	github.com/signadot/go-sdk v0.3.8-0.20260616155342-631831380993
 	github.com/signadot/libconnect v0.1.1-0.20260527212426-31fdd269494f
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/viper v1.11.0

--- a/go.sum
+++ b/go.sum
@@ -456,6 +456,8 @@ github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
 github.com/signadot/go-sdk v0.3.8-0.20260616111829-cf476fc34600 h1:3mf6dzv+EQu/rvCGe7RTX84xTCK3F1Gyubw1YPYbgTM=
 github.com/signadot/go-sdk v0.3.8-0.20260616111829-cf476fc34600/go.mod h1:p+PG9uZvx5RTYtYovQQnrbzzB7a1SQ4A3WYNx6PC2xE=
+github.com/signadot/go-sdk v0.3.8-0.20260616140141-c7f267f6836e h1:Z2M0Zs3p/k9/kuXTYYS4/mZl65eZTp9mRk0vlJga+EM=
+github.com/signadot/go-sdk v0.3.8-0.20260616140141-c7f267f6836e/go.mod h1:p+PG9uZvx5RTYtYovQQnrbzzB7a1SQ4A3WYNx6PC2xE=
 github.com/signadot/libconnect v0.1.1-0.20260527212426-31fdd269494f h1:b8ZzCjMOat1IJ9Y5rTRoy7TjD0Ch/QDu8P5lHuSJoBQ=
 github.com/signadot/libconnect v0.1.1-0.20260527212426-31fdd269494f/go.mod h1:5/CHotq3FQnSv9XQUy3sQkJz240Al1MsJ2wm1wf3usE=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=

--- a/go.sum
+++ b/go.sum
@@ -458,6 +458,8 @@ github.com/signadot/go-sdk v0.3.8-0.20260616111829-cf476fc34600 h1:3mf6dzv+EQu/r
 github.com/signadot/go-sdk v0.3.8-0.20260616111829-cf476fc34600/go.mod h1:p+PG9uZvx5RTYtYovQQnrbzzB7a1SQ4A3WYNx6PC2xE=
 github.com/signadot/go-sdk v0.3.8-0.20260616140141-c7f267f6836e h1:Z2M0Zs3p/k9/kuXTYYS4/mZl65eZTp9mRk0vlJga+EM=
 github.com/signadot/go-sdk v0.3.8-0.20260616140141-c7f267f6836e/go.mod h1:p+PG9uZvx5RTYtYovQQnrbzzB7a1SQ4A3WYNx6PC2xE=
+github.com/signadot/go-sdk v0.3.8-0.20260616155342-631831380993 h1:bF1URmHU+RLBAfDj7asExSv6WClCFwBAP0YPRpg/OjE=
+github.com/signadot/go-sdk v0.3.8-0.20260616155342-631831380993/go.mod h1:p+PG9uZvx5RTYtYovQQnrbzzB7a1SQ4A3WYNx6PC2xE=
 github.com/signadot/libconnect v0.1.1-0.20260527212426-31fdd269494f h1:b8ZzCjMOat1IJ9Y5rTRoy7TjD0Ch/QDu8P5lHuSJoBQ=
 github.com/signadot/libconnect v0.1.1-0.20260527212426-31fdd269494f/go.mod h1:5/CHotq3FQnSv9XQUy3sQkJz240Al1MsJ2wm1wf3usE=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=


### PR DESCRIPTION
> **Draft.** Reviewable together with signadot/signadot#7098 and signadot/go-sdk#81.

Consumes the ENG-933-regenerated go-sdk (signadot/go-sdk#81): `go.mod` points go-sdk at that branch. The go-sdk change is purely additive (8 new endpoints, none dropped), so the CLI builds unchanged. Rebased on current `cli` main (go-openapi/runtime v0.31.0).

Repin to the released go-sdk version once go-sdk#81 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
