### PR TITLE
ENG-1113: -f/--follow for sandbox logs (client-side polling)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/nsf/jsondiff v0.0.0-20210926074059-1e845ec5d249
 	github.com/oklog/run v1.1.0
 	github.com/panta/machineid v1.0.2
-	github.com/signadot/go-sdk v0.3.8-0.20260716213214-9b9414c5699b
+	github.com/signadot/go-sdk v0.3.8-0.20260721194832-06e9e2d4e717
 	github.com/signadot/libconnect v0.1.1-0.20260527212426-31fdd269494f
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/viper v1.11.0

--- a/go.sum
+++ b/go.sum
@@ -454,8 +454,8 @@ github.com/segmentio/encoding v0.5.4 h1:OW1VRern8Nw6ITAtwSZ7Idrl3MXCFwXHPgqESYfv
 github.com/segmentio/encoding v0.5.4/go.mod h1:HS1ZKa3kSN32ZHVZ7ZLPLXWvOVIiZtyJnO1gPH1sKt0=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN3Uc8sB6B/s6Z4t2xvBgU1htSHuq8=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
-github.com/signadot/go-sdk v0.3.8-0.20260716213214-9b9414c5699b h1:OSPmkDGLpMJ80xVGCfQdPPuGBJW1oqC3SkouVnVhnwI=
-github.com/signadot/go-sdk v0.3.8-0.20260716213214-9b9414c5699b/go.mod h1:XceNnt/ujjPO0lJcOWNBMj5hJQtHKsdgi4/gWn9/BdA=
+github.com/signadot/go-sdk v0.3.8-0.20260721194832-06e9e2d4e717 h1:KryXw/yyPJApoSWLc1NdzBDrptQdLxd4Vof1l1ZVAHk=
+github.com/signadot/go-sdk v0.3.8-0.20260721194832-06e9e2d4e717/go.mod h1:XceNnt/ujjPO0lJcOWNBMj5hJQtHKsdgi4/gWn9/BdA=
 github.com/signadot/libconnect v0.1.1-0.20260527212426-31fdd269494f h1:b8ZzCjMOat1IJ9Y5rTRoy7TjD0Ch/QDu8P5lHuSJoBQ=
 github.com/signadot/libconnect v0.1.1-0.20260527212426-31fdd269494f/go.mod h1:5/CHotq3FQnSv9XQUy3sQkJz240Al1MsJ2wm1wf3usE=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=

--- a/internal/command/logs/command.go
+++ b/internal/command/logs/command.go
@@ -34,7 +34,7 @@ func New(api *config.API) *cobra.Command {
 // run dispatches to the sandbox or job log source.
 func run(ctx context.Context, outW, errW io.Writer, cfg *config.Logs) error {
 	if cfg.Sandbox != "" {
-		return showSandboxLogs(ctx, outW, cfg)
+		return showSandboxLogs(ctx, outW, errW, cfg)
 	}
 	return showJobLogs(ctx, outW, errW, cfg)
 }

--- a/internal/command/logs/sandbox.go
+++ b/internal/command/logs/sandbox.go
@@ -4,16 +4,25 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
+	"os/signal"
+	"syscall"
 	"time"
 
 	"github.com/signadot/cli/internal/config"
 	"github.com/signadot/cli/internal/print"
 	"github.com/signadot/go-sdk/client/sandboxes"
+	"github.com/signadot/go-sdk/models"
 )
 
+// followPollInterval is how often the sandbox path re-polls the (snapshot) logs
+// endpoint when --follow is set. Native streaming is a fast-follow (ENG-1115).
+const followPollInterval = 2 * time.Second
+
 // showSandboxLogs fetches logs for a sandbox workload (fork) or resource via the
-// sandbox-scoped logs endpoint and prints them per-container.
-func showSandboxLogs(ctx context.Context, out io.Writer, cfg *config.Logs) error {
+// sandbox-scoped logs endpoint and prints them per-container. With --follow it
+// polls, advancing sinceTime and de-duplicating per container.
+func showSandboxLogs(ctx context.Context, out, errW io.Writer, cfg *config.Logs) error {
 	if cfg.Workload == "" && cfg.Resource == "" {
 		return fmt.Errorf("must specify --workload or --resource with --sandbox")
 	}
@@ -26,6 +35,9 @@ func showSandboxLogs(ctx context.Context, out io.Writer, cfg *config.Logs) error
 	if cfg.Since != "" && cfg.SinceTime != "" {
 		return fmt.Errorf("--since and --since-time are mutually exclusive")
 	}
+	if cfg.Follow && cfg.OutputFormat != config.OutputFormatDefault {
+		return fmt.Errorf("--follow cannot be combined with -o %s", cfg.OutputFormat)
+	}
 
 	sinceTime, err := resolveSinceTime(cfg.Since, cfg.SinceTime)
 	if err != nil {
@@ -36,6 +48,91 @@ func showSandboxLogs(ctx context.Context, out io.Writer, cfg *config.Logs) error
 		return err
 	}
 
+	if cfg.Follow {
+		return followSandboxLogs(ctx, out, errW, cfg, sinceTime)
+	}
+
+	resp, err := fetchSandboxLogs(ctx, cfg, sinceTime)
+	if err != nil {
+		return err
+	}
+
+	switch cfg.OutputFormat {
+	case config.OutputFormatJSON:
+		return print.RawJSON(out, resp)
+	case config.OutputFormatYAML:
+		return print.RawYAML(out, resp)
+	case config.OutputFormatDefault:
+		multi := len(resp) > 1
+		for _, cl := range resp {
+			for _, item := range cl.Logs {
+				printLogLine(out, cl.Container, item.Message, multi)
+			}
+		}
+		return nil
+	default:
+		return fmt.Errorf("unsupported output format: %q", cfg.OutputFormat)
+	}
+}
+
+// followSandboxLogs tails a sandbox source by polling the snapshot endpoint. It
+// advances sinceTime to the oldest per-container high-water mark and de-dupes
+// each container against its last-printed timestamp, so multiple containers
+// (which share a single sinceTime per request) don't lose or repeat lines. The
+// first poll surfaces selector errors (unknown workload/container/etc.);
+// afterwards transient errors (pod not running yet, restarts) are retried.
+func followSandboxLogs(ctx context.Context, out, errW io.Writer, cfg *config.Logs, initialSince string) error {
+	ctx, stop := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	lastByContainer := map[string]time.Time{}
+	since := initialSince
+	first := true
+	var lastErrMsg string
+
+	for {
+		resp, err := fetchSandboxLogs(ctx, cfg, since)
+		if err != nil {
+			if ctx.Err() != nil {
+				return nil // interrupted
+			}
+			if first {
+				return err // validate selectors up front
+			}
+			if msg := err.Error(); msg != lastErrMsg {
+				fmt.Fprintf(errW, "waiting for logs: %s\n", msg)
+				lastErrMsg = msg
+			}
+		} else {
+			lastErrMsg = ""
+			multi := len(resp) > 1
+			for _, cl := range resp {
+				last := lastByContainer[cl.Container]
+				for _, item := range cl.Logs {
+					t, perr := time.Parse(time.RFC3339, item.Time)
+					if perr == nil && !first && !t.After(last) {
+						continue // already printed (boundary dedup)
+					}
+					printLogLine(out, cl.Container, item.Message, multi)
+					if perr == nil && t.After(lastByContainer[cl.Container]) {
+						lastByContainer[cl.Container] = t
+					}
+				}
+			}
+			since = oldestSince(lastByContainer, since)
+			first = false
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-time.After(followPollInterval):
+		}
+	}
+}
+
+// fetchSandboxLogs performs a single GetSandboxLogs call.
+func fetchSandboxLogs(ctx context.Context, cfg *config.Logs, sinceTime string) ([]*models.LogsContainerLogs, error) {
 	params := sandboxes.NewGetSandboxLogsParams().
 		WithContext(ctx).
 		WithOrgName(cfg.Org).
@@ -48,29 +145,34 @@ func showSandboxLogs(ctx context.Context, out io.Writer, cfg *config.Logs) error
 
 	resp, err := cfg.Client.Sandboxes.GetSandboxLogs(params, nil)
 	if err != nil {
-		return err
+		return nil, err
 	}
+	return resp.Payload, nil
+}
 
-	switch cfg.OutputFormat {
-	case config.OutputFormatJSON:
-		return print.RawJSON(out, resp.Payload)
-	case config.OutputFormatYAML:
-		return print.RawYAML(out, resp.Payload)
-	case config.OutputFormatDefault:
-		multi := len(resp.Payload) > 1
-		for _, cl := range resp.Payload {
-			for _, item := range cl.Logs {
-				if multi {
-					fmt.Fprintf(out, "[%s] %s\n", cl.Container, item.Message)
-				} else {
-					fmt.Fprintln(out, item.Message)
-				}
-			}
-		}
-		return nil
-	default:
-		return fmt.Errorf("unsupported output format: %q", cfg.OutputFormat)
+func printLogLine(out io.Writer, container, message string, multi bool) {
+	if multi {
+		fmt.Fprintf(out, "[%s] %s\n", container, message)
+	} else {
+		fmt.Fprintln(out, message)
 	}
+}
+
+// oldestSince returns the RFC3339 timestamp to use for the next poll: the oldest
+// per-container high-water mark (so no container's newer-than-its-own-last lines
+// are skipped by the shared sinceTime). Falls back to the current value when no
+// lines have been seen yet.
+func oldestSince(lastByContainer map[string]time.Time, current string) string {
+	var oldest time.Time
+	for _, t := range lastByContainer {
+		if oldest.IsZero() || t.Before(oldest) {
+			oldest = t
+		}
+	}
+	if oldest.IsZero() {
+		return current
+	}
+	return oldest.UTC().Format(time.RFC3339Nano)
 }
 
 // resolveSinceTime converts the CLI's --since (relative duration) or

--- a/internal/command/logs/sandbox.go
+++ b/internal/command/logs/sandbox.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -75,19 +76,20 @@ func showSandboxLogs(ctx context.Context, out, errW io.Writer, cfg *config.Logs)
 	}
 }
 
-// followSandboxLogs tails a sandbox source by polling the snapshot endpoint. It
-// advances sinceTime to the oldest per-container high-water mark and de-dupes
-// each container against its last-printed timestamp, so multiple containers
-// (which share a single sinceTime per request) don't lose or repeat lines. The
-// first poll surfaces selector errors (unknown workload/container/etc.);
-// afterwards transient errors (pod not running yet, restarts) are retried.
+// followSandboxLogs tails a sandbox source by polling the snapshot endpoint,
+// advancing sinceTime and de-duplicating via followState (see its docs for the
+// per-container high-water-mark + boundary-set scheme). On the first poll a
+// selector error (unknown workload/container/etc.) fails fast; transient errors
+// (pod not running yet, restarts, gateway/connection) are reported once and
+// retried. Stops cleanly on SIGINT/SIGTERM/SIGHUP.
 func followSandboxLogs(ctx context.Context, out, errW io.Writer, cfg *config.Logs, initialSince string) error {
-	ctx, stop := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
+	ctx, stop := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM, syscall.SIGHUP)
 	defer stop()
 
-	lastByContainer := map[string]time.Time{}
+	st := newFollowState()
 	since := initialSince
 	first := true
+	multi := false
 	var lastErrMsg string
 
 	for {
@@ -96,8 +98,8 @@ func followSandboxLogs(ctx context.Context, out, errW io.Writer, cfg *config.Log
 			if ctx.Err() != nil {
 				return nil // interrupted
 			}
-			if first {
-				return err // validate selectors up front
+			if first && !isTransientFollowErr(err) {
+				return err // fail fast on a selector mistake; it won't self-heal
 			}
 			if msg := err.Error(); msg != lastErrMsg {
 				fmt.Fprintf(errW, "waiting for logs: %s\n", msg)
@@ -105,21 +107,20 @@ func followSandboxLogs(ctx context.Context, out, errW io.Writer, cfg *config.Log
 			}
 		} else {
 			lastErrMsg = ""
-			multi := len(resp) > 1
+			// Latch the multi-container prefix once we've seen more than one
+			// container, so a container that starts logging later doesn't flip
+			// earlier lines between prefixed and unprefixed forms.
+			if len(resp) > 1 {
+				multi = true
+			}
 			for _, cl := range resp {
-				last := lastByContainer[cl.Container]
 				for _, item := range cl.Logs {
-					t, perr := time.Parse(time.RFC3339, item.Time)
-					if perr == nil && !first && !t.After(last) {
-						continue // already printed (boundary dedup)
-					}
-					printLogLine(out, cl.Container, item.Message, multi)
-					if perr == nil && t.After(lastByContainer[cl.Container]) {
-						lastByContainer[cl.Container] = t
+					if st.observe(cl.Container, item.Time, item.Message, first) {
+						printLogLine(out, cl.Container, item.Message, multi)
 					}
 				}
 			}
-			since = oldestSince(lastByContainer, since)
+			since = st.sinceTime(since)
 			first = false
 		}
 
@@ -129,6 +130,105 @@ func followSandboxLogs(ctx context.Context, out, errW io.Writer, cfg *config.Log
 		case <-time.After(followPollInterval):
 		}
 	}
+}
+
+// followState de-duplicates streamed log lines across polls. Because every
+// container in a request shares a single sinceTime, we can't advance a global
+// watermark without losing lines from a lagging container; instead each
+// container keeps its own high-water mark (hwm) plus the set of messages seen at
+// exactly that timestamp (boundary). A re-fetched line is printed iff it is
+// strictly newer than the container's hwm, or shares the hwm timestamp but its
+// exact message hasn't been printed yet — so distinct lines sharing the boundary
+// timestamp are NOT dropped. Untimestamped lines can't be de-duplicated, so they
+// are printed only on the first (snapshot) poll and skipped thereafter to avoid
+// reprinting the whole window forever.
+type followState struct {
+	byContainer map[string]*containerCursor
+}
+
+type containerCursor struct {
+	hwm      time.Time
+	hasHWM   bool
+	boundary map[string]struct{}
+}
+
+func newFollowState() *followState {
+	return &followState{byContainer: map[string]*containerCursor{}}
+}
+
+// observe records a line and reports whether it should be printed now. first is
+// true on the initial (snapshot) poll.
+func (s *followState) observe(container, tstr, message string, first bool) bool {
+	c := s.byContainer[container]
+	if c == nil {
+		c = &containerCursor{boundary: map[string]struct{}{}}
+		s.byContainer[container] = c
+	}
+
+	t, err := time.Parse(time.RFC3339, tstr)
+	if tstr == "" || err != nil {
+		// No usable timestamp: can't de-dup across polls, so only emit on the
+		// first poll. (This endpoint always timestamps; this is a safety net.)
+		return first
+	}
+
+	switch {
+	case !c.hasHWM || t.After(c.hwm):
+		c.hwm = t
+		c.hasHWM = true
+		c.boundary = map[string]struct{}{message: {}}
+		return true
+	case t.Equal(c.hwm):
+		if _, seen := c.boundary[message]; seen {
+			return false
+		}
+		c.boundary[message] = struct{}{}
+		return true
+	default: // older than hwm — already printed in an earlier poll
+		return false
+	}
+}
+
+// sinceTime returns the next poll's sinceTime: the oldest per-container hwm (so
+// no lagging container loses lines to the shared filter), or fallback when no
+// timestamped line has been seen.
+func (s *followState) sinceTime(fallback string) string {
+	var oldest time.Time
+	found := false
+	for _, c := range s.byContainer {
+		if !c.hasHWM {
+			continue
+		}
+		if !found || c.hwm.Before(oldest) {
+			oldest = c.hwm
+			found = true
+		}
+	}
+	if !found {
+		return fallback
+	}
+	return oldest.UTC().Format(time.RFC3339Nano)
+}
+
+// isTransientFollowErr reports whether a follow-poll error is worth retrying
+// (pod not running yet, restart, gateway/connection) rather than a selector
+// mistake that won't self-heal. Heuristic on the error text pending typed
+// errors (ENG-1115) — the readiness phrasings are matched explicitly so a
+// "not ready yet" message isn't mistaken for a "<thing> not found" selector error.
+func isTransientFollowErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	m := err.Error()
+	for _, s := range []string{
+		"may not be ready", "no running pods", "not running",
+		"502", "503", "504", "Gateway", "connection", "EOF", "timeout",
+	} {
+		if strings.Contains(m, s) {
+			return true
+		}
+	}
+	return false
 }
 
 // fetchSandboxLogs performs a single GetSandboxLogs call.
@@ -156,23 +256,6 @@ func printLogLine(out io.Writer, container, message string, multi bool) {
 	} else {
 		fmt.Fprintln(out, message)
 	}
-}
-
-// oldestSince returns the RFC3339 timestamp to use for the next poll: the oldest
-// per-container high-water mark (so no container's newer-than-its-own-last lines
-// are skipped by the shared sinceTime). Falls back to the current value when no
-// lines have been seen yet.
-func oldestSince(lastByContainer map[string]time.Time, current string) string {
-	var oldest time.Time
-	for _, t := range lastByContainer {
-		if oldest.IsZero() || t.Before(oldest) {
-			oldest = t
-		}
-	}
-	if oldest.IsZero() {
-		return current
-	}
-	return oldest.UTC().Format(time.RFC3339Nano)
 }
 
 // resolveSinceTime converts the CLI's --since (relative duration) or

--- a/internal/command/logs/sandbox.go
+++ b/internal/command/logs/sandbox.go
@@ -2,6 +2,7 @@ package logs
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -14,11 +15,24 @@ import (
 	"github.com/signadot/cli/internal/print"
 	"github.com/signadot/go-sdk/client/sandboxes"
 	"github.com/signadot/go-sdk/models"
+	"github.com/signadot/go-sdk/transport"
 )
 
 // followPollInterval is how often the sandbox path re-polls the (snapshot) logs
 // endpoint when --follow is set. Native streaming is a fast-follow (ENG-1115).
 const followPollInterval = 2 * time.Second
+
+// followRewindGrace bounds how far back the shared sinceTime may rewind for the
+// next poll (see followState.sinceTime). A few poll intervals: enough that a
+// still-active container that's merely lagging keeps its lines, without pinning
+// the whole request window to a container that logged once and went quiet.
+const followRewindGrace = 3 * followPollInterval
+
+// serverTailCap mirrors the control plane's per-container logReqTailLines cap
+// (sandboxes/internal/control/logs/pods/fetch.go). A poll that returns exactly
+// this many lines for a container was almost certainly truncated, so --follow
+// warns rather than silently dropping the older lines.
+const serverTailCap = 1000
 
 // showSandboxLogs fetches logs for a sandbox workload (fork) or resource via the
 // sandbox-scoped logs endpoint and prints them per-container. With --follow it
@@ -91,6 +105,7 @@ func followSandboxLogs(ctx context.Context, out, errW io.Writer, cfg *config.Log
 	first := true
 	multi := false
 	var lastErrMsg string
+	capped := map[string]bool{} // containers currently hitting the server tail cap
 
 	for {
 		resp, err := fetchSandboxLogs(ctx, cfg, since)
@@ -119,6 +134,17 @@ func followSandboxLogs(ctx context.Context, out, errW io.Writer, cfg *config.Log
 						printLogLine(out, cl.Container, item.Message, multi)
 					}
 				}
+				// The server caps each container at serverTailCap lines per
+				// fetch; hitting it means older lines in this interval were
+				// dropped. Warn once per burst (and again if it recurs after
+				// recovering) rather than silently losing lines under load.
+				if hit := len(cl.Logs) >= serverTailCap; hit != capped[cl.Container] {
+					if hit {
+						fmt.Fprintf(errW, "warning: %q is logging faster than --follow can poll; showing only the most recent %d lines per %s (older lines dropped)\n",
+							cl.Container, serverTailCap, followPollInterval)
+					}
+					capped[cl.Container] = hit
+				}
 			}
 			since = st.sinceTime(since)
 			first = false
@@ -138,10 +164,13 @@ func followSandboxLogs(ctx context.Context, out, errW io.Writer, cfg *config.Log
 // container keeps its own high-water mark (hwm) plus the set of messages seen at
 // exactly that timestamp (boundary). A re-fetched line is printed iff it is
 // strictly newer than the container's hwm, or shares the hwm timestamp but its
-// exact message hasn't been printed yet — so distinct lines sharing the boundary
-// timestamp are NOT dropped. Untimestamped lines can't be de-duplicated, so they
-// are printed only on the first (snapshot) poll and skipped thereafter to avoid
-// reprinting the whole window forever.
+// exact message hasn't been printed yet. This keeps the client from dropping a
+// distinct line that shares the boundary timestamp with one already printed —
+// but only among the lines the server re-sends: the container that *defines* the
+// shared sinceTime won't receive such a line at all, because the server filters
+// on a strict After(sinceTime). Untimestamped lines can't be de-duplicated, so
+// they are printed only on the first (snapshot) poll and skipped thereafter to
+// avoid reprinting the whole window forever.
 type followState struct {
 	byContainer map[string]*containerCursor
 }
@@ -189,42 +218,90 @@ func (s *followState) observe(container, tstr, message string, first bool) bool 
 	}
 }
 
-// sinceTime returns the next poll's sinceTime: the oldest per-container hwm (so
-// no lagging container loses lines to the shared filter), or fallback when no
-// timestamped line has been seen.
+// sinceTime returns the next poll's sinceTime. All containers share one
+// sinceTime, so it rewinds to the oldest per-container hwm to avoid dropping a
+// lagging container's lines — but no further back than followRewindGrace behind
+// the newest hwm. Without that clamp a container that logs once at startup and
+// goes quiet (a startup-only sidecar such as istio-proxy, or a completed
+// resource create-step pod) pins sinceTime at its stale mark forever, so every
+// poll re-requests the whole capped window from it through the cluster tunnel.
+// Containers in a pod share a clock, so a genuinely lagging *active* container
+// won't be more than a few poll intervals behind the newest line. Returns
+// fallback when no timestamped line has been seen.
 func (s *followState) sinceTime(fallback string) string {
-	var oldest time.Time
+	var oldest, newest time.Time
 	found := false
 	for _, c := range s.byContainer {
 		if !c.hasHWM {
 			continue
 		}
-		if !found || c.hwm.Before(oldest) {
+		if !found {
+			oldest, newest, found = c.hwm, c.hwm, true
+			continue
+		}
+		if c.hwm.Before(oldest) {
 			oldest = c.hwm
-			found = true
+		}
+		if c.hwm.After(newest) {
+			newest = c.hwm
 		}
 	}
 	if !found {
 		return fallback
 	}
+	if floor := newest.Add(-followRewindGrace); oldest.Before(floor) {
+		oldest = floor
+	}
 	return oldest.UTC().Format(time.RFC3339Nano)
 }
 
 // isTransientFollowErr reports whether a follow-poll error is worth retrying
-// (pod not running yet, restart, gateway/connection) rather than a selector
-// mistake that won't self-heal. Heuristic on the error text pending typed
-// errors (ENG-1115) — the readiness phrasings are matched explicitly so a
-// "not ready yet" message isn't mistaken for a "<thing> not found" selector error.
+// (pod not running yet, restart, gateway/tunnel hiccup) rather than a selector
+// mistake that won't self-heal.
+//
+// It decides on the go-sdk's *transport.APIError (the FixAPIErrors middleware
+// wraps every 4xx/5xx in one), never on err.Error(): the formatted string
+// prefixes the HTTP status text and splices in the selector the user typed plus
+// the list of valid names, so a fork or container legitimately named
+// "connection-pool" or "timeout-worker" would make a genuine typo match a
+// substring and retry forever. A 5xx is a gateway/tunnel/k8s hiccup (retry); a
+// 4xx is a client mistake and only the readiness cases — which the server also
+// returns as 4xx ("...may not be ready yet" / "no running pods found...") —
+// are transient, matched against the server's own message field alone. A
+// non-API error is a transport failure before the server answered, so retry.
 func isTransientFollowErr(err error) bool {
 	if err == nil {
 		return false
 	}
-	m := err.Error()
-	for _, s := range []string{
-		"may not be ready", "no running pods", "not running",
-		"502", "503", "504", "Gateway", "connection", "EOF", "timeout",
-	} {
-		if strings.Contains(m, s) {
+	var apiErr *transport.APIError
+	if errors.As(err, &apiErr) {
+		switch {
+		case apiErr.Code >= 500:
+			return true
+		case apiErr.Code >= 400:
+			// ErrorResponse.Error is the clean server message — no status
+			// prefix, no request id, no echoed selector list.
+			return isReadinessMsg(apiErr.ErrorResponse.Error)
+		default:
+			return false
+		}
+	}
+	// Not an API response: the request failed at the transport layer
+	// (connection reset, EOF, timeout) before the server replied — retry.
+	return isTransportErr(err.Error())
+}
+
+// isReadinessMsg matches the server's "sandbox not ready yet" messages, the
+// only 4xx cases worth retrying under --follow.
+func isReadinessMsg(msg string) bool {
+	return strings.Contains(msg, "may not be ready") ||
+		strings.Contains(msg, "no running pods")
+}
+
+// isTransportErr matches connection-level failures (no HTTP response received).
+func isTransportErr(msg string) bool {
+	for _, s := range []string{"connection", "EOF", "timeout", "no such host", "reset by peer"} {
+		if strings.Contains(msg, s) {
 			return true
 		}
 	}

--- a/internal/command/logs/sandbox_test.go
+++ b/internal/command/logs/sandbox_test.go
@@ -1,6 +1,13 @@
 package logs
 
-import "testing"
+import (
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/signadot/go-sdk/transport"
+)
 
 // step is one observe() call in a scripted follow sequence.
 type step struct {
@@ -76,5 +83,54 @@ func TestFollowStateSinceTime(t *testing.T) {
 	st2.observe("notime", "", "x", true)
 	if got := st2.sinceTime("FB"); got != "FB" {
 		t.Errorf("sinceTime with only untimestamped = %q, want FB", got)
+	}
+
+	// Rewind clamp: a container that logged once and went quiet sits far behind
+	// the newest mark; sinceTime must not rewind past newest-grace, else every
+	// poll re-requests that stale container's whole window forever.
+	st3 := newFollowState()
+	st3.observe("live", "2026-01-01T00:01:00Z", "a", true)
+	st3.observe("stopped", "2026-01-01T00:00:00Z", "b", true) // 60s behind, grace is smaller
+	newest := time.Date(2026, 1, 1, 0, 1, 0, 0, time.UTC)
+	want := newest.Add(-followRewindGrace).UTC().Format(time.RFC3339Nano)
+	if got := st3.sinceTime("FB"); got != want {
+		t.Errorf("sinceTime clamp = %q, want %q (newest-grace)", got, want)
+	}
+}
+
+// wrappedAPIErr mimics what the go-sdk FixAPIErrors middleware returns: a
+// *transport.APIError (clean server message + HTTP status code) wrapped behind
+// the HTTP status text, e.g. "400 Bad Request: <message>". The wrapping is what
+// makes err.Error() dangerous to match on and why the guard uses errors.As.
+func wrappedAPIErr(code int, message string) error {
+	apiErr := &transport.APIError{}
+	apiErr.Code = int64(code)
+	apiErr.ErrorResponse.Error = message
+	return fmt.Errorf("%d %s: %w", code, "Status", apiErr)
+}
+
+func TestIsTransientFollowErr(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"5xx gateway", wrappedAPIErr(502, "can't fetch logs from cluster"), true},
+		{"503 unavailable", wrappedAPIErr(503, "can't fetch pod from cluster"), true},
+		{"4xx readiness (not ready yet)", wrappedAPIErr(400, "no running pods found for the forked workload; the sandbox may not be ready yet"), true},
+		// Regression (Scott): a fork/container named "connection-pool" or
+		// "timeout-worker" puts "connection"/"timeout" in the message, but it's
+		// a plain selector error -> must fail fast, not retry forever.
+		{"4xx selector with connection-pool name", wrappedAPIErr(400, `container "connection-pool" not found; containers: app, istio-proxy`), false},
+		{"4xx selector with timeout-worker name", wrappedAPIErr(400, `workload "timeout-worker" not found in sandbox "s"; loggable workloads: app`), false},
+		{"transport failure (no response)", errors.New("dial tcp 10.0.0.1:443: connect: connection refused"), true},
+		{"transport EOF", errors.New("unexpected EOF"), true},
+		{"unrelated non-API error", errors.New("something else entirely"), false},
+	}
+	for _, c := range cases {
+		if got := isTransientFollowErr(c.err); got != c.want {
+			t.Errorf("%s: isTransientFollowErr(%v) = %v, want %v", c.name, c.err, got, c.want)
+		}
 	}
 }

--- a/internal/command/logs/sandbox_test.go
+++ b/internal/command/logs/sandbox_test.go
@@ -1,0 +1,80 @@
+package logs
+
+import "testing"
+
+// step is one observe() call in a scripted follow sequence.
+type step struct {
+	container string
+	time      string
+	message   string
+	first     bool
+	wantPrint bool
+}
+
+func runObserveSteps(t *testing.T, name string, steps []step) {
+	t.Helper()
+	st := newFollowState()
+	for i, s := range steps {
+		if got := st.observe(s.container, s.time, s.message, s.first); got != s.wantPrint {
+			t.Errorf("%s step %d observe(%q,%q,%q,first=%v)=%v, want %v",
+				name, i, s.container, s.time, s.message, s.first, got, s.wantPrint)
+		}
+	}
+}
+
+func TestFollowStateObserve(t *testing.T) {
+	// Duplicate timestamp across a poll boundary: the re-sent line at the
+	// high-water timestamp is suppressed, but a *distinct* line sharing that
+	// exact timestamp is still printed (regression guard for the naive
+	// "<= last" filter that would drop it).
+	runObserveSteps(t, "boundary-same-timestamp", []step{
+		{"app", "2026-01-01T00:00:02Z", "a", true, true},   // poll1: new
+		{"app", "2026-01-01T00:00:02Z", "a", false, false}, // poll2: exact dup at boundary
+		{"app", "2026-01-01T00:00:02Z", "b", false, true},  // poll2: distinct line, same ts -> keep
+		{"app", "2026-01-01T00:00:03Z", "c", false, true},  // poll2: newer
+	})
+
+	// A line older than the high-water mark was already printed earlier.
+	runObserveSteps(t, "older-than-hwm", []step{
+		{"app", "2026-01-01T00:00:05Z", "x", true, true},
+		{"app", "2026-01-01T00:00:03Z", "y", false, false},
+	})
+
+	// Untimestamped lines can't be de-duplicated: print on the first poll,
+	// skip afterwards so the window isn't reprinted forever.
+	runObserveSteps(t, "empty-timestamp", []step{
+		{"svc", "", "m", true, true},
+		{"svc", "", "m", false, false},
+		{"svc", "", "n", false, false},
+	})
+
+	// Two containers advance independently and don't suppress each other.
+	runObserveSteps(t, "independent-containers", []step{
+		{"app", "2026-01-01T00:00:02Z", "a", true, true},
+		{"sidecar", "2026-01-01T00:00:02Z", "a", true, true}, // same ts+msg, different container
+		{"sidecar", "2026-01-01T00:00:02Z", "a", false, false},
+	})
+}
+
+func TestFollowStateSinceTime(t *testing.T) {
+	// No lines seen yet -> fall back to the caller's value.
+	if got := newFollowState().sinceTime("FALLBACK"); got != "FALLBACK" {
+		t.Errorf("sinceTime with no data = %q, want FALLBACK", got)
+	}
+
+	// Lagging container: use the OLDEST per-container high-water mark so the
+	// shared sinceTime doesn't skip the lagging container's newer lines.
+	st := newFollowState()
+	st.observe("fast", "2026-01-01T00:00:05Z", "a", true)
+	st.observe("slow", "2026-01-01T00:00:02Z", "b", true)
+	if got, want := st.sinceTime("FALLBACK"), "2026-01-01T00:00:02Z"; got != want {
+		t.Errorf("sinceTime = %q, want %q (oldest hwm)", got, want)
+	}
+
+	// A container with only untimestamped lines contributes no hwm.
+	st2 := newFollowState()
+	st2.observe("notime", "", "x", true)
+	if got := st2.sinceTime("FB"); got != "FB" {
+		t.Errorf("sinceTime with only untimestamped = %q, want FB", got)
+	}
+}

--- a/internal/config/logs.go
+++ b/internal/config/logs.go
@@ -18,6 +18,7 @@ type Logs struct {
 	Resource  string
 	Step      string
 	Container string
+	Follow    bool
 
 	// Selectors shared where applicable.
 	TailLines uint
@@ -39,6 +40,7 @@ func (c *Logs) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&c.Container, "container", "c", "", "container name to display; defaults to all containers")
 	cmd.Flags().StringVar(&c.Since, "since", "", "only display logs newer than a relative duration, e.g. 10m, 1h, 2h30m")
 	cmd.Flags().StringVar(&c.SinceTime, "since-time", "", "only display logs after an RFC3339 timestamp")
+	cmd.Flags().BoolVarP(&c.Follow, "follow", "f", false, "follow the log output (sandbox path; jobs already stream)")
 
 	// --job and --sandbox are different log sources. Reject cross-source flags
 	// rather than silently ignoring them:

--- a/internal/config/logs.go
+++ b/internal/config/logs.go
@@ -50,7 +50,9 @@ func (c *Logs) AddFlags(cmd *cobra.Command) {
 	cmd.MarkFlagsMutuallyExclusive("job", "sandbox")
 	cmd.MarkFlagsMutuallyExclusive("stream", "sandbox")
 	cmd.MarkFlagsMutuallyExclusive("tail", "sandbox")
-	for _, sandboxOnly := range []string{"workload", "resource", "step", "container", "since", "since-time"} {
+	// --follow only drives the sandbox path (the job path streams via SSE
+	// regardless), so reject it with --job rather than silently ignoring it.
+	for _, sandboxOnly := range []string{"workload", "resource", "step", "container", "since", "since-time", "follow"} {
 		cmd.MarkFlagsMutuallyExclusive("job", sandboxOnly)
 	}
 }


### PR DESCRIPTION
## What

Adds `-f/--follow` to `signadot logs` for the **sandbox** path (ENG-1113).

Stacked on #351 (ENG-1112) — base is `feat/sandbox-logs`; will retarget to `main` once #351 merges.

The sandbox-scoped endpoint is a point-in-time snapshot, so follow tails by polling on an interval (2s) and advancing `sinceTime`. Native pod-log streaming is a fast-follow (ENG-1115). The job path already streams via SSE and is unchanged.

## Correctness

- **Per-container de-dup.** All containers share a single `sinceTime` per request, so a global high-water mark would drop lines from a lagging container. Instead each container is de-duped against its own last-printed timestamp, and the next poll uses the *oldest* per-container high-water mark — no lost or repeated lines across multiple containers.
- **Error handling.** The first poll surfaces selector errors (unknown workload/container/resource/step) so a typo fails fast; subsequent transient errors (pod not running yet, restarts) are reported once to stderr and retried.
- **Graceful stop** on SIGINT/SIGTERM.
- Rejected with `-o json|yaml` (follow streams plain lines only).

## Testing (live, local cluster)

Followed a 2-container fork (`app` + `sidecar`, each logging every 1s):

```console
$ signadot logs --sandbox follow-test --workload multi -f
[app] APP 0
[sidecar] SIDE 0
[app] APP 1
...
```

- ~10s of `-f`: **70 lines, 70 unique (0 duplicates)**, 35 `[app]` + 35 `[sidecar]`, sequential with no gaps.
- `-f -c app` → single container, raw (unprefixed), tails live.
- `-f -o json` → `Error: --follow cannot be combined with -o json`.
- `-f --workload nope` → first poll surfaces `400 … workload "nope" not found …`.
- SIGTERM/Ctrl-C → stops promptly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
