### PR TITLE
add OIDC workflow for MCP registry publish

### DIFF
--- a/.github/workflows/mcp-registry-publish.yaml
+++ b/.github/workflows/mcp-registry-publish.yaml
@@ -1,0 +1,38 @@
+name: Publish to MCP Registry
+
+# Publishes the MCP server entry for a released CLI version to the official
+# MCP registry (https://registry.modelcontextprotocol.io) using GitHub Actions
+# OIDC, which grants the io.github.signadot/* namespace to workflows in this
+# org's repositories. Run it after the release artifacts are live.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release tag to publish (e.g. v1.8.0)"
+        required: true
+        type: string
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # OIDC token for mcp-publisher login github-oidc
+      contents: read
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+    - name: Generate server.json from release artifacts
+      env:
+        VERSION: ${{ inputs.version }}
+      run: ./scripts/gen-mcp-server-json.sh "$VERSION"
+
+    - name: Install mcp-publisher
+      run: |
+        curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+
+    - name: Log in to MCP registry (OIDC)
+      run: ./mcp-publisher login github-oidc
+
+    - name: Publish server.json
+      run: ./mcp-publisher publish server.json


### PR DESCRIPTION
Interactive `mcp-publisher login github` can't get the `io.github.signadot/*` namespace — the registry's GitHub App is private/uninstallable so its user tokens can't see org memberships (modelcontextprotocol/registry#398). GitHub Actions OIDC grants the org namespace directly. Manual `workflow_dispatch` with a version input; run after release artifacts are live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)