### PR TITLE
README: document PAT requirement for MCP registry org publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,20 @@ After the GitHub release artifacts are live, publish the MCP server entry
 manually. goreleaser does not yet support the `fileSha256` integrity field
 required by the MCP registry for `mcpb` packages.
 
-**Prerequisite:** install [`mcp-publisher`](https://github.com/modelcontextprotocol/registry).
+**Prerequisites:**
+
+- install [`mcp-publisher`](https://github.com/modelcontextprotocol/registry)
+- a classic GitHub PAT with only the `read:org` scope
+  ([create one here](https://github.com/settings/tokens/new?scopes=read:org&description=mcp-registry-publish)),
+  owned by an **Owner** of the signadot org. Since
+  [registry#1383](https://github.com/modelcontextprotocol/registry/pull/1383)
+  the registry grants the `io.github.signadot/*` namespace only to org Owners,
+  and the interactive `mcp-publisher login github` device flow cannot read org
+  roles — logging in with a PAT is what makes org publishing work.
 
 ```sh
-./scripts/gen-mcp-server-json.sh <version>   # e.g. v1.5.0 — writes server.json
-mcp-publisher login github
+./scripts/gen-mcp-server-json.sh <version>   # e.g. v1.8.0 — writes server.json
+MCP_GITHUB_TOKEN=<pat-with-read:org> mcp-publisher login github
 mcp-publisher publish server.json
 ```
 

--- a/scripts/gen-mcp-server-json.sh
+++ b/scripts/gen-mcp-server-json.sh
@@ -91,7 +91,9 @@ echo "" >&2
 echo "Generated ${OUTPUT}" >&2
 echo "" >&2
 
-echo "Run the following commands to publish to the MCP registry:"
+echo "Run the following commands to publish to the MCP registry"
+echo "(org publishing requires a classic PAT with the read:org scope,"
+echo "owned by a signadot org Owner — see README):"
 echo ""
-echo "  mcp-publisher login github"
+echo "  MCP_GITHUB_TOKEN=<pat-with-read:org> mcp-publisher login github"
 echo "  mcp-publisher publish ${OUTPUT}"


### PR DESCRIPTION
Since modelcontextprotocol/registry#1383 (July 2026), the io.github.signadot/* namespace is granted only to org Owners, and the interactive device-flow login can't read org roles. Documents the working flow: classic PAT with read:org via MCP_GITHUB_TOKEN. Also updates the hint printed by gen-mcp-server-json.sh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)