### PR TITLE
job list: opt into the paginated ListJobs response

### DIFF
--- a/internal/command/jobs/list.go
+++ b/internal/command/jobs/list.go
@@ -38,9 +38,8 @@ func list(cfg *config.JobList, out io.Writer) error {
 	if err := cfg.InitAPIConfig(); err != nil {
 		return err
 	}
-	optIn := jobsPaginationOptIn
 	resp, err := cfg.Client.Jobs.ListJobs(
-		jobs.NewListJobsParams().WithOrgName(cfg.Org).WithSignadotAPIOptIn(&optIn),
+		jobs.NewListJobsParams().WithOrgName(cfg.Org).WithSignadotAPIOptIn([]string{jobsPaginationOptIn}),
 		nil,
 	)
 	if err != nil {

--- a/internal/command/jobs/list.go
+++ b/internal/command/jobs/list.go
@@ -27,22 +27,34 @@ func newList(job *config.Job) *cobra.Command {
 	return cmd
 }
 
+// jobsPaginationOptIn opts into the server's paginated ListJobs response
+// ({items, nextCursor, hasMore, totalCount, totalPages} instead of a bare
+// array) — see signadot/signadot#7328. The CLI's own -o json/-o yaml output
+// stays a plain job array either way (below), so this is purely about not
+// depending on the legacy server-side path ahead of its 2026-11-16 sunset.
+const jobsPaginationOptIn = "jobs-pagination"
+
 func list(cfg *config.JobList, out io.Writer) error {
 	if err := cfg.InitAPIConfig(); err != nil {
 		return err
 	}
-	resp, err := cfg.Client.Jobs.ListJobs(jobs.NewListJobsParams().WithOrgName(cfg.Org), nil)
+	optIn := jobsPaginationOptIn
+	resp, err := cfg.Client.Jobs.ListJobs(
+		jobs.NewListJobsParams().WithOrgName(cfg.Org).WithSignadotAPIOptIn(&optIn),
+		nil,
+	)
 	if err != nil {
 		return err
 	}
+	items := resp.Payload.Items
 
 	switch cfg.OutputFormat {
 	case config.OutputFormatDefault:
-		return printJobTable(cfg, out, resp.Payload)
+		return printJobTable(cfg, out, items)
 	case config.OutputFormatJSON:
-		return print.RawJSON(out, resp.Payload)
+		return print.RawJSON(out, items)
 	case config.OutputFormatYAML:
-		return print.RawYAML(out, resp.Payload)
+		return print.RawYAML(out, items)
 	default:
 		return fmt.Errorf("unsupported output format: %q", cfg.OutputFormat)
 	}

--- a/internal/command/jobs/list.go
+++ b/internal/command/jobs/list.go
@@ -27,19 +27,21 @@ func newList(job *config.Job) *cobra.Command {
 	return cmd
 }
 
-// jobsPaginationOptIn opts into the server's paginated ListJobs response
-// ({items, nextCursor, hasMore, totalCount, totalPages} instead of a bare
-// array) — see signadot/signadot#7328. The CLI's own -o json/-o yaml output
-// stays a plain job array either way (below), so this is purely about not
-// depending on the legacy server-side path ahead of its 2026-11-16 sunset.
-const jobsPaginationOptIn = "jobs-pagination"
+// jobsPaginationAPIVersion pins to the API version at/after which ListJobs
+// returns the paginated response ({items, nextCursor, hasMore, totalCount,
+// totalPages} instead of a bare array) — see signadot/signadot#7328. The
+// CLI's own -o json/-o yaml output stays a plain job array either way
+// (below), so this is purely about not depending on the legacy server-side
+// path ahead of its 2026-11-16 sunset.
+const jobsPaginationAPIVersion = "2026-08-18"
 
 func list(cfg *config.JobList, out io.Writer) error {
 	if err := cfg.InitAPIConfig(); err != nil {
 		return err
 	}
+	apiVersion := jobsPaginationAPIVersion
 	resp, err := cfg.Client.Jobs.ListJobs(
-		jobs.NewListJobsParams().WithOrgName(cfg.Org).WithSignadotAPIOptIn([]string{jobsPaginationOptIn}),
+		jobs.NewListJobsParams().WithOrgName(cfg.Org).WithSignadotAPIVersion(&apiVersion),
 		nil,
 	)
 	if err != nil {

--- a/internal/command/jobs/list.go
+++ b/internal/command/jobs/list.go
@@ -27,21 +27,20 @@ func newList(job *config.Job) *cobra.Command {
 	return cmd
 }
 
-// jobsPaginationAPIVersion pins to the API version at/after which ListJobs
-// returns the paginated response ({items, nextCursor, hasMore, totalCount,
-// totalPages} instead of a bare array) — see signadot/signadot#7328. The
-// CLI's own -o json/-o yaml output stays a plain job array either way
-// (below), so this is purely about not depending on the legacy server-side
-// path ahead of its 2026-11-16 sunset.
-const jobsPaginationAPIVersion = "2026-08-18"
+// jobsPaginationOptIn opts into the server's paginated ListJobs response
+// ({items, nextCursor, hasMore, totalCount, totalPages} instead of a bare
+// array) — see signadot/signadot#7328. The CLI's own -o json/-o yaml output
+// stays a plain job array either way (below), so this is purely about not
+// depending on the legacy server-side path ahead of its 2026-11-16 sunset.
+const jobsPaginationOptIn = "pagination"
 
 func list(cfg *config.JobList, out io.Writer) error {
 	if err := cfg.InitAPIConfig(); err != nil {
 		return err
 	}
-	apiVersion := jobsPaginationAPIVersion
+	optIn := jobsPaginationOptIn
 	resp, err := cfg.Client.Jobs.ListJobs(
-		jobs.NewListJobsParams().WithOrgName(cfg.Org).WithSignadotAPIVersion(&apiVersion),
+		jobs.NewListJobsParams().WithOrgName(cfg.Org).WithSignadotAPIOptIn(&optIn),
 		nil,
 	)
 	if err != nil {


### PR DESCRIPTION
## Summary
`ListJobs` now returns a `{items, nextCursor, hasMore, totalCount, totalPages}` envelope when the caller opts in (signadot/signadot#7328). This sends `signadot-api-opt-in: pagination` and reads `resp.Payload.Items` instead of `resp.Payload`.

**Final header design** (settled after a couple of iterations): a single value, `signadot-api-opt-in: pagination` — not a list, not a dated version. `WithSignadotAPIOptIn(*string)`.

The CLI's own `-o json`/`-o yaml` output is unchanged — still a plain job array — only the wire format between the CLI and the server changed.

**Blocked on** signadot/go-sdk#92 (regenerated client) merging and getting tagged, since `ListJobsParams.SignadotAPIOptIn` and `ListJobsOK.Payload` (now `*models.ListJobsResponse`) don't exist in the currently-pinned `v0.3.8`. `go.mod` isn't bumped in this PR — that's a one-line follow-up once go-sdk ships a new tag. Marked as a draft for that reason.

## Test plan
- [x] Verified locally against the regenerated go-sdk branch (temporary `replace` directive, not committed) + a live host-run apiserver + seeded MySQL: `job list` table view, `job list --all`, `job list -o json`, `job list -o yaml` all work and match pre-change output shape
- [x] Confirmed via generated `WriteToRequest` that `signadot-api-opt-in` is sent as a header (not a query param)
- [ ] Bump `github.com/signadot/go-sdk` to the tagged version once signadot/go-sdk#92 merges, un-draft

🤖 Generated with [Claude Code](https://claude.com/claude-code)