### PR TITLE
sandbox apply: --dry-run to render a spec without applying it

### DIFF
--- a/internal/command/sandbox/apply.go
+++ b/internal/command/sandbox/apply.go
@@ -28,7 +28,12 @@ func newApply(sandbox *config.Sandbox) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "apply -f FILENAME [ --set var1=val1 --set var2=val2 ... ]",
 		Short: "Create or update a sandbox with variable expansion",
-		Args:  cobra.NoArgs,
+		Long: `Create or update a sandbox with variable expansion.
+
+--dry-run=client renders the spec and validates it locally, printing the result
+instead of applying it, and needs no API credentials. The output is a spec, so it
+can be reviewed, diffed, and passed straight back to -f.`,
+		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return apply(cfg, cmd.OutOrStdout(), cmd.ErrOrStderr(), args)
 		},
@@ -42,20 +47,34 @@ func apply(cfg *config.SandboxApply, out, log io.Writer, args []string) error {
 		os.Interrupt, syscall.SIGTERM, syscall.SIGTERM, syscall.SIGHUP)
 	defer cancel()
 
-	if err := cfg.InitAPIConfig(); err != nil {
-		return err
-	}
 	if cfg.Filename == "" {
 		return errors.New("must specify sandbox request file with '-f' flag")
 	}
+	if cfg.DryRun == config.DryRunServer {
+		return errors.New("--dry-run=server is not available yet; " +
+			"use --dry-run=client to render and validate locally")
+	}
 
-	// Load the sandbox spec
-	req, err := loadSandbox(cfg.Filename, cfg.TemplateVals, false /*forDelete */)
+	// Render before authenticating, so that --dry-run=client works with no
+	// credentials at all and a spec that cannot be rendered fails the same way
+	// whether or not the caller is logged in.
+	doc, err := utils.LoadUnstructuredTemplate(cfg.Filename, cfg.TemplateVals, false /* forDelete */)
+	if err != nil {
+		return err
+	}
+	req, err := unstructuredToSandbox(doc)
 	if err != nil {
 		return err
 	}
 	if req.Spec.Cluster == nil {
 		return fmt.Errorf("sandbox spec must specify cluster")
+	}
+	if cfg.DryRun == config.DryRunClient {
+		return writeRenderedSpec(cfg, out, doc)
+	}
+
+	if err := cfg.InitAPIConfig(); err != nil {
+		return err
 	}
 
 	var status *sbmapi.StatusResponse
@@ -115,6 +134,19 @@ func apply(cfg *config.SandboxApply, out, log io.Writer, args []string) error {
 		return nil
 	}
 	return writeOutput(cfg, out, resp)
+}
+
+// writeRenderedSpec prints the rendered spec for --dry-run. YAML is the default
+// because the output's job is to be read, diffed, and fed back to -f.
+func writeRenderedSpec(cfg *config.SandboxApply, out io.Writer, doc any) error {
+	switch cfg.OutputFormat {
+	case config.OutputFormatDefault, config.OutputFormatYAML:
+		return print.RawYAML(out, doc)
+	case config.OutputFormatJSON:
+		return print.RawJSON(out, doc)
+	default:
+		return fmt.Errorf("unsupported output format: %q", cfg.OutputFormat)
+	}
 }
 
 func writeOutput(cfg *config.SandboxApply, out io.Writer, resp *models.Sandbox) error {

--- a/internal/command/sandbox/apply_test.go
+++ b/internal/command/sandbox/apply_test.go
@@ -1,0 +1,134 @@
+package sandbox
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/signadot/cli/internal/config"
+)
+
+const dryRunTemplate = `name: test-sandbox
+spec:
+  cluster: my-cluster
+  description: build @{tag}
+  forks:
+    - forkOf:
+        kind: Deployment
+        name: route
+        namespace: hotrod
+      customizations:
+        images:
+          - image: acme/route:@{tag}
+`
+
+// dryRunConfig builds an apply config with no credentials of any kind, so that a
+// test reaching authentication fails rather than silently using the developer's
+// own login.
+func dryRunConfig(t *testing.T, file string, mode config.DryRunMode, sets ...string) *config.SandboxApply {
+	t.Helper()
+	cfg := &config.SandboxApply{
+		Sandbox:  &config.Sandbox{API: &config.API{}},
+		Filename: file,
+		DryRun:   mode,
+	}
+	for _, s := range sets {
+		if err := cfg.TemplateVals.Set(s); err != nil {
+			t.Fatalf("--set %s: %v", s, err)
+		}
+	}
+	return cfg
+}
+
+func writeTemp(t *testing.T, name, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func render(t *testing.T, file string, sets ...string) string {
+	t.Helper()
+	var out, log bytes.Buffer
+	cfg := dryRunConfig(t, file, config.DryRunClient, sets...)
+	if err := apply(cfg, &out, &log, nil); err != nil {
+		t.Fatalf("--dry-run=client: %v", err)
+	}
+	return out.String()
+}
+
+// The point of --dry-run=client is that it renders and validates without
+// contacting anything, so it has to work for a caller who has never logged in.
+func TestDryRunClientNeedsNoCredentials(t *testing.T) {
+	got := render(t, writeTemp(t, "sandbox.yaml", dryRunTemplate), "tag=abc123")
+
+	for _, want := range []string{"name: test-sandbox", "acme/route:abc123", "build abc123"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("rendered spec is missing %q:\n%s", want, got)
+		}
+	}
+
+	// InitAPIConfig is what builds the client, so an unset client is the evidence
+	// that rendering returned before authentication was even attempted.
+	cfg := dryRunConfig(t, writeTemp(t, "sandbox.yaml", dryRunTemplate), config.DryRunClient)
+	if err := cfg.TemplateVals.Set("tag=abc123"); err != nil {
+		t.Fatal(err)
+	}
+	var out, log bytes.Buffer
+	if err := apply(cfg, &out, &log, nil); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Client != nil {
+		t.Error("--dry-run=client initialised an API client")
+	}
+}
+
+// The Action renders in one step and applies those exact bytes in another, which
+// only holds if a rendered spec renders to itself.
+func TestDryRunOutputIsAFixedPoint(t *testing.T) {
+	once := render(t, writeTemp(t, "sandbox.yaml", dryRunTemplate), "tag=abc123")
+	twice := render(t, writeTemp(t, "rendered.yaml", once))
+
+	if once != twice {
+		t.Errorf("re-rendering changed the spec:\nfirst:\n%s\nsecond:\n%s", once, twice)
+	}
+	if strings.Contains(once, "@{") {
+		t.Errorf("rendered spec still carries a placeholder:\n%s", once)
+	}
+}
+
+// Local validation is worth having only if it reports what the API would.
+func TestDryRunClientValidates(t *testing.T) {
+	for name, tc := range map[string]struct{ doc, want string }{
+		"no cluster":    {"name: sb\nspec:\n  description: nothing\n", "cluster"},
+		"unknown field": {"name: sb\nspec:\n  cluster: c\n  forkz: []\n", "unknown field"},
+		"unset var":     {"name: sb-@{missing}\nspec:\n  cluster: c\n", "missing"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			cfg := dryRunConfig(t, writeTemp(t, "sandbox.yaml", tc.doc), config.DryRunClient)
+			var out, log bytes.Buffer
+			err := apply(cfg, &out, &log, nil)
+			if err == nil {
+				t.Fatalf("expected an error, got output:\n%s", out.String())
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error %q does not mention %q", err, tc.want)
+			}
+		})
+	}
+}
+
+// The mode exists in the flag's grammar so that adding it later needs no new
+// spelling, but it has nothing behind it yet.
+func TestDryRunServerIsRejected(t *testing.T) {
+	cfg := dryRunConfig(t, writeTemp(t, "sandbox.yaml", dryRunTemplate), config.DryRunServer)
+	var out, log bytes.Buffer
+	err := apply(cfg, &out, &log, nil)
+	if err == nil || !strings.Contains(err.Error(), "not available yet") {
+		t.Errorf("got %v, want an error saying server dry run is not available yet", err)
+	}
+}

--- a/internal/config/flag_types.go
+++ b/internal/config/flag_types.go
@@ -35,6 +35,40 @@ func (o *OutputFormat) Type() string {
 	return "string"
 }
 
+// DryRunMode follows kubectl's --dry-run, so that the distinction between
+// rendering locally and asking the server to validate is the one people already
+// know.
+type DryRunMode string
+
+const (
+	// DryRunNone applies normally.
+	DryRunNone DryRunMode = "none"
+	// DryRunClient renders and validates locally, without contacting the API.
+	DryRunClient DryRunMode = "client"
+	// DryRunServer additionally asks the API to validate. Not yet available.
+	DryRunServer DryRunMode = "server"
+)
+
+func (m *DryRunMode) String() string {
+	return string(*m)
+}
+
+// Set implements the pflag.Value interface.
+func (m *DryRunMode) Set(v string) error {
+	switch DryRunMode(v) {
+	case DryRunNone, DryRunClient, DryRunServer:
+		*m = DryRunMode(v)
+		return nil
+	default:
+		return fmt.Errorf("unknown dry-run mode %q: expected one of none, client, server", v)
+	}
+}
+
+// Type implements the pflag.Value interface.
+func (m *DryRunMode) Type() string {
+	return "none|client|server"
+}
+
 var (
 	VarRx = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9_.-]*$`)
 )

--- a/internal/config/sandbox.go
+++ b/internal/config/sandbox.go
@@ -18,6 +18,7 @@ type SandboxApply struct {
 	Wait         bool
 	WaitTimeout  time.Duration
 	TemplateVals TemplateVals
+	DryRun       DryRunMode
 }
 
 func (c *SandboxApply) AddFlags(cmd *cobra.Command) {
@@ -26,6 +27,9 @@ func (c *SandboxApply) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().DurationVar(&c.WaitTimeout, "wait-timeout", 3*time.Minute, "timeout when waiting for the sandbox to be Ready")
 	cmd.MarkFlagRequired("filename")
 	cmd.Flags().Var(&c.TemplateVals, "set", "--set var=val")
+
+	c.DryRun = DryRunNone
+	cmd.Flags().Var(&c.DryRun, "dry-run", "print the rendered sandbox spec instead of applying it: \"client\" renders and validates locally")
 }
 
 type SandboxDelete struct {


### PR DESCRIPTION
## What this does

Adds `--dry-run=none|client|server` to `signadot sandbox apply`. `client` renders the
spec, validates it, and prints it instead of applying it:

```console
$ signadot sandbox apply -f .signadot/template.yaml --set tag=$(git rev-parse HEAD) --dry-run=client
name: acme-web-1234
spec:
  cluster: prod-eks
  forks:
    - forkOf:
        kind: Deployment
        name: web
        namespace: acme
      customizations:
        images:
          - image: ghcr.io/acme/web:5f2c1a0
```

## Why

Rendering a template has always been local, but the only way to see what it produced
was to apply the sandbox. That leaves two things unserved: CI cannot show what it is
about to do, and a template cannot be checked without creating something.

The rendering step already existed and already ran locally — it just ran *after*
authentication. Moving it before authentication is most of this change, and it means
`--dry-run=client` works for someone who has never logged in, and fails identically
whether or not they have.

The output is a spec, not a report, so it can be reviewed, diffed, and passed straight
back to `-f`. `TestDryRunOutputIsAFixedPoint` pins that: re-rendering a rendered spec
changes nothing. That property is what lets a caller render in one step and apply
exactly those bytes in another, which is how the sandbox GitHub Action
([ENG-1187](https://linear.app/signadot/issue/ENG-1187/signadot-sandbox-github-action-poc))
gets a `rendered-spec` output that is provably what was applied.

`--dry-run=server` is accepted by the flag and rejected at runtime, since it needs a
`validateOnly` parameter on the apiserver that does not exist yet
([ENG-1203](https://linear.app/signadot/issue/ENG-1203/server-side-dry-run-for-sandbox-apply-validateonly)).
Keeping it in the grammar now means adding it later needs no new spelling, and the
distinction between rendering locally and asking the server to validate is the one
`kubectl` users already know.

## Scope

Deliberately small and self-contained. It is the first of two: the larger change on
[#361](https://github.com/signadot/cli/pull/361) proposes a values document and a
built-in template so a sandbox can be described without authoring a template at all.
That one is a design decision and is still a draft. This one stands on its own for
anyone who already has a template.

One behaviour change beyond the new flag: the "sandbox spec must specify cluster" check
now happens before authentication rather than after, so a spec missing a cluster reports
that instead of an auth failure. Existing valid invocations are unaffected.

## Test plan

- [x] `go test ./internal/...`
- [x] `--dry-run=client` renders `--set` substitutions and never builds an API client,
      so it cannot be reaching the network
- [x] Rendered output re-renders to itself byte for byte
- [x] Local validation reports a missing cluster, an unknown spec field, and an
      unexpanded `@{var}`
- [x] `--dry-run=server` is rejected with a message pointing at the follow-up
- [ ] Reviewer sanity check: `apply -f <your template> --dry-run=client` against a real
      template, with and without being logged in
