### PR TITLE
fix(print): handle carriage returns in --attach text output

### DIFF
--- a/internal/print/attach.go
+++ b/internal/print/attach.go
@@ -78,7 +78,7 @@ func formatText(e AttachEvent) string {
 		if e.Stream != "" {
 			fmt.Fprintf(&b, " stream=%s", e.Stream)
 		}
-		fmt.Fprintf(&b, " msg=%s", quoteIfNeeded(strings.TrimRight(e.Msg, "\n")))
+		fmt.Fprintf(&b, " msg=%s", quoteIfNeeded(strings.TrimRight(e.Msg, "\r\n")))
 	case "output":
 		fmt.Fprintf(&b, " name=%s", e.Name)
 		if e.Step != "" {
@@ -124,7 +124,7 @@ func formatText(e AttachEvent) string {
 }
 
 func quoteIfNeeded(s string) string {
-	if s == "" || strings.ContainsAny(s, " \t\n\"=") {
+	if s == "" || strings.ContainsAny(s, " \t\n\r\"=") {
 		return fmt.Sprintf("%q", s)
 	}
 	return s

--- a/internal/print/attach_test.go
+++ b/internal/print/attach_test.go
@@ -1,0 +1,60 @@
+package print
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestQuoteIfNeeded(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"plain", "plain", "plain"},
+		{"empty", "", `""`},
+		{"space", "a b", `"a b"`},
+		{"equals", "k=v", `"k=v"`},
+		{"tab", "a\tb", `"a\tb"`},
+		{"newline", "a\nb", `"a\nb"`},
+		{"carriage_return", "a\rb", `"a\rb"`},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := quoteIfNeeded(tc.in)
+			if got != tc.want {
+				t.Errorf("quoteIfNeeded(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+			if strings.ContainsRune(got, '\r') {
+				t.Errorf("quoteIfNeeded(%q) leaked a raw carriage return: %q", tc.in, got)
+			}
+		})
+	}
+}
+
+func TestFormatTextLogTrimsTrailingCRLF(t *testing.T) {
+	out := formatText(AttachEvent{Type: "log", Msg: "hello\r\n"})
+	if strings.ContainsRune(out, '\r') {
+		t.Errorf("formatText leaked a raw carriage return: %q", out)
+	}
+	if !strings.Contains(out, "msg=hello") {
+		t.Errorf("formatText(%q) = %q, want it to contain msg=hello", "hello\r\n", out)
+	}
+}
+
+func TestFormatTextLogEscapesEmbeddedCR(t *testing.T) {
+	out := formatText(AttachEvent{Type: "log", Msg: "line1\rline2"})
+	if strings.ContainsRune(out, '\r') {
+		t.Errorf("formatText leaked a raw carriage return: %q", out)
+	}
+	if !strings.Contains(out, `msg="line1\rline2"`) {
+		t.Errorf("formatText(%q) = %q, want the message quoted with an escaped CR", "line1\rline2", out)
+	}
+}
+
+func TestFormatTextLogPlainMsgUnquoted(t *testing.T) {
+	out := formatText(AttachEvent{Type: "log", Msg: "plain"})
+	if !strings.Contains(out, "msg=plain") {
+		t.Errorf("formatText(%q) = %q, want unquoted msg=plain", "plain", out)
+	}
+}


### PR DESCRIPTION
While reading the --attach output code I noticed the text formatter can leak raw carriage returns into terminal output.

In formatText, the log message is trimmed with strings.TrimRight(e.Msg, "\n"), which drops a trailing \n but leaves a trailing \r. And quoteIfNeeded forces quoting on " \t\n\"=" but not \r. So a log line ending in \r\n prints as msg=<text> followed by a bare \r, and an embedded \r inside a message prints raw too. On a terminal that \r sends the cursor back to the start of the line and the next write overwrites it. CRLF endings are common (Windows apps, plenty of containers), so this turns up in real logs.

The fix is small:
- trim "\r\n" instead of "\n"
- add \r to the set that forces quoting, so an embedded \r is escaped as \r instead of emitted raw

JSON mode already handled this, since json.Marshal escapes control characters, so this only affects the text output.

This package had no tests, so I added the first ones. They cover quoteIfNeeded across the special characters and the log path for trailing CRLF, embedded CR, and a plain message.

    go test ./internal/print/
    ok  github.com/signadot/cli/internal/print

I checked each assertion pins the fix: reverting the trim fails only TestFormatTextLogTrimsTrailingCRLF, and reverting the quoteIfNeeded change fails only the carriage-return cases. gofmt is clean.